### PR TITLE
[FIX] Installation dependency

### DIFF
--- a/report_xls/__openerp__.py
+++ b/report_xls/__openerp__.py
@@ -75,7 +75,6 @@ Excel reports in odoo.
 
     """,
     'depends': ['base'],
-    'external_dependencies': {'python': ['xlwt']},
     'active': False,
     'installable': True,
 }


### PR DESCRIPTION
Ubuntu 14.04 - Odoo 8
While trying to install this module, a "no module xlwt" appears even if the module is properly installed.
Removing this line the module could be installed without error messages.
