### PR TITLE
report_custom_filename : filename is not mandatory

### DIFF
--- a/report_custom_filename/controllers/reports.py
+++ b/report_custom_filename/controllers/reports.py
@@ -37,7 +37,7 @@ class Reports(main.Reports):
             [('report_name', '=', action['report_name'])],
             0, False, False, context)
         for report in report_xml.read(report_ids, fields=['download_filename']):
-            if not report['download_filename']:
+            if not report.get('download_filename'):
                 continue
             objects = req.session.model(context['active_model'])\
                 .browse(context['active_ids'])


### PR DESCRIPTION
On report without custom filename, I get the following message when I try to get them :

Client Traceback (most recent call last):
  File "/home/openerp/instances/preprod/parts/openerp/addons/web/http.py", line 287, in dispatch
    r = method(self, **self.params)
  File "/home/openerp/instances/preprod/addons-reporting-engine/report_custom_filename/controllers/reports.py", line 40, in index
    if not report['download_filename']:
KeyError: 'download_filename'
