### PR TITLE
Only import what is needed (otherwise, eval = safe_eval)

### DIFF
--- a/report_xls/report_xls.py
+++ b/report_xls/report_xls.py
@@ -28,7 +28,7 @@ from openerp.osv.fields import datetime as datetime_field
 from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
 import inspect
 from types import CodeType
-from openerp.report.report_sxw import *
+from openerp.report.report_sxw import report_sxw
 from openerp import pooler
 from openerp.tools.translate import translate, _
 import logging


### PR DESCRIPTION
This PR is to correct an issue introduced with the addition in https://github.com/OCA/OCB/commit/53980b7c524a054dc497e314e8bcfff0e76ee3db#diff-7f72654b443301d0fe1533f309bb3c8aR39 : in `report_xls` , the import from `report_sxw` imported everything ( https://github.com/OCA/reporting-engine/blob/7.0/report_xls/report_xls.py#L31 ), including now this redefinition of `eval`.

It was then called on `CodeType` instances, as shown in https://github.com/OCA/reporting-engine/blob/7.0/report_xls/report_xls.py#L164 , but since it was the `openerp.tools.safe_eval` , an error was returned in the report "Export Selected Lines" on move lines.
