### PR TITLE
[FIX] add arg to workbook creation

### DIFF
--- a/report_xls/report_xls.py
+++ b/report_xls/report_xls.py
@@ -120,7 +120,9 @@ class report_xls(report_sxw):
         parser_instance.set_context(objs, data, ids, 'xls')
         objs = parser_instance.localcontext['objects']
         n = cStringIO.StringIO()
-        wb = xlwt.Workbook(encoding='utf-8')
+        # prevent style make error
+        # http://stackoverflow.com/questions/17130516/xlwt-set-style-making-error-more-than-4094-xfs-styles
+        wb = xlwt.Workbook(encoding='utf-8', style_compression=2)
         _p = AttrDict(parser_instance.localcontext)
         _xs = self.xls_styles
         self.xls_headers = {


### PR DESCRIPTION
## Issue

When you use a lot of styles applied to a big number of cells, you fall into this error
http://stackoverflow.com/questions/17130516/xlwt-set-style-making-error-more-than-4094-xfs-styles
## Solution

this fix
