### PR TITLE
[FIX] [report_xls] Override the field to add the value instead of breaking the validation system

### DIFF
--- a/report_xls/ir_report.py
+++ b/report_xls/ir_report.py
@@ -20,15 +20,10 @@
 #
 ##############################################################################
 
-from openerp import models
+from openerp import models, fields
 
 
 class IrActionsReportXml(models.Model):
     _inherit = 'ir.actions.report.xml'
 
-    def _check_selection_field_value(self, cr, uid,
-                                     field, value, context=None):
-        if field == 'report_type' and value == 'xls':
-            return
-        return super(IrActionsReportXml, self)._check_selection_field_value(
-            cr, uid, field, value, context=context)
+    report_type = fields.Selection(selection_add=[('xls', 'XLS')])


### PR DESCRIPTION
I think this is better to override the field in the new API way, to really add a possible value in the selection, instead of "breaking" the fields's value validation system.

This also allows Odoo to display the "XLS" value in the reports list, instead of "unknown".
