### PR TITLE
[FIX][report_xls] Protect import.

### DIFF
--- a/report_xls/report_xls.py
+++ b/report_xls/report_xls.py
@@ -29,13 +29,29 @@ from types import CodeType
 from openerp.report.report_sxw import report_sxw
 from openerp import pooler
 import logging
+
 _logger = logging.getLogger(__name__)
+
+xls_types_default = {
+    'bool': False,
+    'date': None,
+    'text': '',
+    'number': 0,
+}
 
 try:
     import xlwt
     from xlwt.Style import default_style
+
+    xls_types = {
+        'bool': xlwt.Row.set_cell_boolean,
+        'date': xlwt.Row.set_cell_date,
+        'text': xlwt.Row.set_cell_text,
+        'number': xlwt.Row.set_cell_number,
+    }
 except ImportError:
     _logger.debug("Cannot import xlwt. This module will not be functional.")
+    xls_types = xls_types_default
 
 
 class AttrDict(dict):
@@ -45,22 +61,7 @@ class AttrDict(dict):
 
 
 class report_xls(report_sxw):
-
-    xls_types = {
-        'bool': xlwt.Row.set_cell_boolean,
-        'date': xlwt.Row.set_cell_date,
-        'text': xlwt.Row.set_cell_text,
-        'number': xlwt.Row.set_cell_number,
-    }
-    xls_types_default = {
-        'bool': False,
-        'date': None,
-        'text': '',
-        'number': 0,
-    }
-
     # TO DO: move parameters infra to configurable data
-
     # header/footer
     hf_params = {
         'font_size': 8,

--- a/report_xls/report_xls.py
+++ b/report_xls/report_xls.py
@@ -49,7 +49,7 @@ try:
         'text': xlwt.Row.set_cell_text,
         'number': xlwt.Row.set_cell_number,
     }
-except ImportError:
+except ImportError:  # pragma: no cover
     _logger.debug("Cannot import xlwt. This module will not be functional.")
     xls_types = xls_types_default
 


### PR DESCRIPTION
Even after merging 2bf93a1d49f7c79062ab7c237ceb794cdbdec983, import still breaks when trying to use module's stuff at class definition time when module is not imported.

I move xsl types to a failure-safe scope.

I checked that no other modules use these variables.

@Tecnativa
