### PR TITLE
[FIX][report_xls] Add a variable when import fails.

### DIFF
--- a/report_xls/report_xls.py
+++ b/report_xls/report_xls.py
@@ -52,6 +52,7 @@ try:
 except ImportError:  # pragma: no cover
     _logger.debug("Cannot import xlwt. This module will not be functional.")
     xls_types = xls_types_default
+    default_style = None
 
 
 class AttrDict(dict):


### PR DESCRIPTION
Otherwise you can get errors like:

```
    from . import reporting_xls
  File "/opt/odoo/available/OCA/l10n-spain/account_balance_reporting_xls/report/reporting_xls.py", line#
Please enter the commit message for your changes. Lines starting
 31, in <module># with '#' will be ignored, and an empty message aborts the commit.
    from openerp.addons.report_xls.report_xls import report_xls# On branch 8.0-report_xls-protected_import
  File "/opt/odoo/available/OCA/OCB/openerp/modules/module.py", line 80, in load_module# Changes to be
committed:
    mod = imp.load_module('openerp.addons.' + module_part, f, path, descr)# modified: report_xls.py
  File "/opt/odoo/available/OCA/reporting-engine/report_xls/__init__.py", line 24, in <module>#
    from . import report_xls
  File "/opt/odoo/available/OCA/reporting-engine/report_xls/report_xls.py", line 63, in <module>
    class report_xls(report_sxw):
  File "/opt/odoo/available/OCA/reporting-engine/report_xls/report_xls.py", line 230, in report_xls
    row_style=default_style, set_column_size=False):
NameError: name 'default_style' is not defined
```

@Tecnativa
