### PR TITLE
[FIX] report_xlsx: Protect import + CamelCase class

### DIFF
--- a/report_xlsx/README.rst
+++ b/report_xlsx/README.rst
@@ -22,9 +22,14 @@ An example of XLSX report for partners:
 
 A python class ::
 
-    from openerp.addons.report_xlsx.report.report_xlsx import ReportXlsx
+    try:
+        from openerp.addons.report_xlsx.report.report_xlsx import ReportXlsx
+    except ImportError:
+        class ReportXlsx(object):
+            def __init__(self, *args, **kwargs):
+                pass
 
-    class partner_xlsx(ReportXlsx):
+    class PartnerXlsx(ReportXlsx):
 
         def generate_xlsx_report(self, workbook, data, partners):
             for obj in partners:
@@ -35,8 +40,7 @@ A python class ::
                 sheet.write(0, 0, obj.name, bold)
 
 
-    partner_xlsx('report.res.partner.xlsx',
-                 'res.partner')
+    PartnerXlsx('report.res.partner.xlsx', 'res.partner')
 
 To manipulate the ``workbook`` and ``sheet`` objects, refer to the
 `documentation <http://xlsxwriter.readthedocs.org/>`_ of ``xlsxwriter``.


### PR DESCRIPTION
This includes improvements in the README to avoid to generate modules depending on this one that generates problems:
- Protect the import to avoid the breakage when you don't have _report_xlsx_ module accessible.
- Put the name of the class in CamelCase as PEP8 says.
