### PR TITLE
[FIX] use JSON instead of simplejson

### DIFF
--- a/report_custom_filename/controllers/reports.py
+++ b/report_custom_filename/controllers/reports.py
@@ -2,7 +2,7 @@
 # Copyright 2014 Therp BV (<http://therp.nl>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import JSON
+import json
 from openerp import http
 from openerp.addons.web.controllers import main
 from openerp.addons.mail.models import mail_template
@@ -13,7 +13,7 @@ class Reports(main.Reports):
     @main.serialize_exception
     def index(self, action, token):
         result = super(Reports, self).index(action, token)
-        action = JSON.parse(action)
+        action = json.loads(action)
         context = dict(http.request.context)
         context.update(action["context"])
         report_xml = http.request.session.model('ir.actions.report.xml')

--- a/report_custom_filename/controllers/reports.py
+++ b/report_custom_filename/controllers/reports.py
@@ -2,7 +2,7 @@
 # Copyright 2014 Therp BV (<http://therp.nl>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import simplejson
+import JSON
 from openerp import http
 from openerp.addons.web.controllers import main
 from openerp.addons.mail.models import mail_template
@@ -13,7 +13,7 @@ class Reports(main.Reports):
     @main.serialize_exception
     def index(self, action, token):
         result = super(Reports, self).index(action, token)
-        action = simplejson.loads(action)
+        action = JSON.parse(action)
         context = dict(http.request.context)
         context.update(action["context"])
         report_xml = http.request.session.model('ir.actions.report.xml')


### PR DESCRIPTION
in 9, we should use the `JSON` library instead of simplejson because this is Odoo's new standard dependency for json issues