### PR TITLE
[9.0][report_custom_filename] Remove simplejson dependency.

### DIFF
--- a/report_custom_filename/README.rst
+++ b/report_custom_filename/README.rst
@@ -27,6 +27,7 @@ Contributors
 ------------
 
 * Holger Brunn <hbrunn@therp.nl>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Icon
 ----

--- a/report_custom_filename/controllers/reports.py
+++ b/report_custom_filename/controllers/reports.py
@@ -2,7 +2,7 @@
 # Copyright 2014 Therp BV (<http://therp.nl>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import simplejson
+import json
 from openerp import http
 from openerp.addons.web.controllers import main
 from openerp.addons.mail.models import mail_template
@@ -13,7 +13,7 @@ class Reports(main.Reports):
     @main.serialize_exception
     def index(self, action, token):
         result = super(Reports, self).index(action, token)
-        action = simplejson.loads(action)
+        action = json.loads(action)
         context = dict(http.request.context)
         context.update(action["context"])
         report_xml = http.request.session.model('ir.actions.report.xml')


### PR DESCRIPTION
Currently this dependency was not listed under `external_dependencies`, and violates https://github.com/OCA/maintainer-quality-tools/pull/354, which leads to `ImportError` under some environments.

Since it adds no benefit over Python's core `json` implementation, I'm simply removing the dependency.

@Tecnativa