### PR TITLE
[9.0] [FIX] report_custom_filename: Don't change the initial HTTP response …

### DIFF
--- a/report_custom_filename/controllers/report_controller.py
+++ b/report_custom_filename/controllers/report_controller.py
@@ -41,6 +41,9 @@ class ReportController(ReportController):
     @http.route(['/report/download'])
     def report_download(self, data, token):
         response = super(ReportController, self).report_download(data, token)
+        if response.status_code != 200:
+            # In case of error don't change the response.
+            return response
         # if we got another content disposition before, ditch the one added
         # by super()
         last_index = None

--- a/report_custom_filename/controllers/reports.py
+++ b/report_custom_filename/controllers/reports.py
@@ -13,6 +13,9 @@ class Reports(main.Reports):
     @main.serialize_exception
     def index(self, action, token):
         result = super(Reports, self).index(action, token)
+        if result.status_code != 200:
+            # In case of error don't change the response.
+            return result
         action = json.loads(action)
         context = dict(http.request.context)
         context.update(action["context"])


### PR DESCRIPTION
…if not OK.

If an error occurs into the base class, the response received from the call to super is already an HTTP error response.
By modifying this response we break the UI since this reponse is no more the one expeceted in case or error.
This change into the initial HTTP reŝponse leeds to different kind of errors into the UI depending of
the browser used. (Invalid CSRF error, UI locked in waiting response or 'Blocked a frame with origin http://localhost:8069 from accessing a cross-origin frame' or ...)