### PR TITLE
Fix py3o freeze when using server fusion

### DIFF
--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -247,7 +247,7 @@ class Py3oReport(models.TransientModel):
             if report_xml.py3o_is_local_fusion:
                 template.render(localcontext)
                 out_stream.seek(0)
-                in_stream = out_stream.read()
+                tmpl_data = out_stream.read()
                 datadict = {}
             else:
                 expressions = template.get_all_user_python_expression()
@@ -260,7 +260,7 @@ class Py3oReport(models.TransientModel):
         if not is_native or not report_xml.py3o_is_local_fusion:
             # Call py3o.server to render the template in the desired format
             files = {
-                'tmpl_file': in_stream,
+                'tmpl_file': tmpl_data,
             }
             fields = {
                 "targetformat": filetype,


### PR DESCRIPTION
The template file has been partially read for the parsing of the
expressions, so use the original template data instead.  When the fusion
server receives an incomplete template, we don't receive any answer
back.