### PR TITLE
[10.0] report_py3o: add option py3o_multi_in_one

### DIFF
--- a/report_py3o/models/ir_actions_report_xml.py
+++ b/report_py3o/models/ir_actions_report_xml.py
@@ -80,6 +80,12 @@ class IrActionsReportXml(models.Model):
             "or an absolute path on your server."
         ))
     report_type = fields.Selection(selection_add=[('py3o', "Py3o")])
+    py3o_multi_in_one = fields.Boolean(
+        string='Multiple Records in a Single Report',
+        help="If you execute a report on several records, "
+        "by default Odoo will generate a ZIP file that contains as many "
+        "files as selected records. If you enable this option, Odoo will "
+        "generate instead a single report for the selected records.")
 
     @api.model
     def render_report(self, res_ids, name, data):

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -282,8 +282,9 @@ class Py3oReport(models.TransientModel):
             with open(result_path, 'w+') as fd:
                 for chunk in r.iter_content(chunk_size):
                     fd.write(chunk)
-        self._postprocess_report(
-            result_path, model_instance.id, save_in_attachment)
+        if len(model_instance) == 1:
+            self._postprocess_report(
+                result_path, model_instance.id, save_in_attachment)
         return result_path
 
     @api.multi
@@ -345,10 +346,17 @@ class Py3oReport(models.TransientModel):
         save_in_attachment = self._check_attachment_use(
             res_ids, self.ir_actions_report_xml_id) or {}
         reports_path = []
-        for model_instance in model_instances:
+        if (
+                len(res_ids) > 1 and
+                self.ir_actions_report_xml_id.py3o_multi_in_one):
             reports_path.append(
-                self._get_or_create_single_report(
-                    model_instance, data, save_in_attachment))
+                self._create_single_report(
+                    model_instances, data, save_in_attachment))
+        else:
+            for model_instance in model_instances:
+                reports_path.append(
+                    self._get_or_create_single_report(
+                        model_instance, data, save_in_attachment))
 
         result_path, filetype = self._merge_results(reports_path)
         reports_path.append(result_path)

--- a/report_py3o/views/ir_report.xml
+++ b/report_py3o/views/ir_report.xml
@@ -15,6 +15,7 @@
 
                     <group name="py3o_params">
                         <field name="py3o_filetype" />
+                        <field name="py3o_multi_in_one"/>
                         <field name="py3o_is_local_fusion"/>
                         <field name="py3o_server_id" />
                         <field name="py3o_template_id" />


### PR DESCRIPTION
I added this option to be able to have severals records in the same report. For example: you need to print several invoices at once. If you select N invoices and ask for the report, Odoo will generate a zip file with N ODT files inside. With this option, Odoo will generate 1 ODT file with the N invoices inside.

This code has been written rapidly for "make it work" for one of my users and I don't have much experience about the internals of report_py3o...