### PR TITLE
IMP add colors constant for xlsx format

### DIFF
--- a/report_xlsx/report/report_xlsx.py
+++ b/report_xlsx/report/report_xlsx.py
@@ -15,6 +15,11 @@ try:
 except ImportError:
     _logger.debug('Can not import xlsxwriter`.')
 
+AVAILABLE_COLORS = ('cyan', 'black', 'blue', 'brown', 'cadet blue',
+                    'dark green', 'magenta', 'green', 'lime', 'navy',
+                    'orange', 'pink', 'purple', 'red', 'silver', 'white',
+                    'yellow')
+
 
 class ReportXlsx(report_sxw):
 


### PR DESCRIPTION
Xlsx writer don't provide documentation about available colors.

This PR add a constant of colors available

Tested with Libreoffice
![test](https://cloud.githubusercontent.com/assets/1853434/25802789/34510b4a-33f4-11e7-81a3-08b9f365d6be.png)

Download full file here
[colors.xlsx](https://github.com/OCA/reporting-engine/files/983314/colors.xlsx)
