### PR TITLE
[10.0][report_qweb_parameter] fix error in VAT validation during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 cache: pip
 
 addons:
@@ -16,20 +17,18 @@ env:
   global:
   - VERSION="10.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
   - TRANSIFEX_USER='transbot@odoo-community.org'
+  - WKHTMLTOPDF_VERSION=0.12.4
   - secure: NUsXwVrMntcqge1ozKW+DSkP7dq+Rla6JVvFF2c89/g+zJaIqQRi8EQBLoqNwCdMk+rjpQeZt/JPELjH+EzPcmGddhDxOgVB3nUT9LvFXGCHF+NjmHXqyba4tuc7BnpG1WDD+rSlxVCt1aIjNIhhaZ4ic0rCWpKNYu/yFTsmChc=
+
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
   - TESTS="1" ODOO_REPO="odoo/odoo"
   - TESTS="1" ODOO_REPO="OCA/OCB"
 
-virtualenv:
-  system_site_packages: true
-
 install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
-  - export WKHTMLTOPDF_VERSION=0.12.4
   - travis_install_nightly
 
 script:

--- a/report_qweb_parameter/demo/test_report_field_length.xml
+++ b/report_qweb_parameter/demo/test_report_field_length.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-
-    <report
-            id="test_report_length_report_id"
-            model="res.company"
-            string="Length Report"
-            report_type="qweb-pdf"
-            name="report_qweb_parameter.test_report_length"
-    />
-
     <template id="test_report_length">
         <t t-call="report.html_container">
             <li name="esc_length" t-minlength="10" t-length="10"

--- a/report_qweb_parameter/tests/test_report_qweb_parameter.py
+++ b/report_qweb_parameter/tests/test_report_qweb_parameter.py
@@ -13,6 +13,7 @@ class TestReportQWebParameter(common.TransactionCase):
         report_object = self.env['ir.actions.report.xml']
         report_name = 'report_qweb_parameter.test_report_length'
         docs = self.env['res.company'].search([], limit=1)
+        country_us = self.env.ref('base.us')
         vat = docs.vat
         website = docs.website
         fax = docs.fax
@@ -21,6 +22,7 @@ class TestReportQWebParameter(common.TransactionCase):
             'fax': '12345678901',
             'vat': '12345678901',
             'website': '1234567890',
+            'country_id': country_us.id,
             'company_registry': '1234567890'
         })
         rep = report_object.render_report(docs.ids, report_name, False)

--- a/report_qweb_parameter/tests/test_report_qweb_parameter.py
+++ b/report_qweb_parameter/tests/test_report_qweb_parameter.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 
 from odoo.addons.base.ir.ir_qweb import QWebException
 from odoo.tests import common
@@ -10,7 +10,6 @@ from odoo.tests import common
 
 class TestReportQWebParameter(common.TransactionCase):
     def test_qweb_parameter(self):
-        report_object = self.env['ir.actions.report.xml']
         report_name = 'report_qweb_parameter.test_report_length'
         docs = self.env['res.company'].search([], limit=1)
         country_us = self.env.ref('base.us')
@@ -25,25 +24,24 @@ class TestReportQWebParameter(common.TransactionCase):
             'country_id': country_us.id,
             'company_registry': '1234567890'
         })
-        rep = report_object.render_report(docs.ids, report_name, False)
-        root = ET.fromstring(
-            rep[0]
-            )
+        docs.check_report = True
+        rep = self.env['report'].render(report_name, {'docs': docs})
+        root = ET.fromstring(rep)
         self.assertEqual(root[1][0][0][0].text, "1234567890")
         self.assertEqual(root[1][0][0][2].text, "1234567890")
         docs.update({'fax': '123456789'})
         with self.assertRaises(QWebException):
-            report_object.render_report(docs.ids, report_name, False)
+            self.env['report'].render(report_name, {'docs': docs})
         docs.update({'fax': '1234567890', 'vat': '123456789'})
         with self.assertRaises(QWebException):
-            report_object.render_report(docs.ids, report_name, False)
+            self.env['report'].render(report_name, {'docs': docs})
         docs.update({'vat': '1234567890', 'website': '12345678901'})
         with self.assertRaises(QWebException):
-            report_object.render_report(docs.ids, report_name, False)
+            self.env['report'].render(report_name, {'docs': docs})
         docs.update(
             {'website': '1234567890', 'company_registry': '12345678901'})
         with self.assertRaises(QWebException):
-            report_object.render_report(docs.ids, report_name, False)
+            self.env['report'].render(report_name, {'docs': docs})
         docs.update({
             'fax': fax,
             'vat': vat,


### PR DESCRIPTION
The tests of `report_qweb_parameter` fail when the company is in a country where the vat code being tested is not valid.

cc @etobella 