### PR TITLE
[10.0][report_qweb_pdf_watermark] Fixes on tests and use pyPDF2

### DIFF
--- a/report_qweb_pdf_watermark/README.rst
+++ b/report_qweb_pdf_watermark/README.rst
@@ -8,6 +8,11 @@ Pdf watermark
 
 This module was written to add watermarks (backgrounds) to PDF reports. Because of the way wkhtmltopdf handles headers and footers in the current versions, it is quite impossible to have a background for the complete page using HTML and CSS. That is why this module inserts the image at the PDF level.
 
+Installation
+============
+
+This module works out of the box, but is faster if you install the python library PyPDF2.
+
 Usage
 =====
 

--- a/report_qweb_pdf_watermark/__manifest__.py
+++ b/report_qweb_pdf_watermark/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Pdf watermark",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Therp BV, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/report_qweb_pdf_watermark/models/report.py
+++ b/report_qweb_pdf_watermark/models/report.py
@@ -3,16 +3,22 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from base64 import b64decode
 from logging import getLogger
-from pyPdf import PdfFileWriter, PdfFileReader
-from pyPdf.utils import PdfReadError
 from PIL import Image
 from StringIO import StringIO
-from odoo import api, models, tools
-from PIL import PdfImagePlugin # flake8: noqa
 
-# PdfImagePlugin must be loaded in order to work PNG to PDF transformation
-# This issue is related to Pillow creation, as can be seen in its source code:
-# https://github.com/python-pillow/Pillow/blob/master/PIL/PdfImagePlugin.py
+from pyPdf import PdfFileWriter, PdfFileReader
+from pyPdf.utils import PdfReadError
+try:
+    from PyPDF2 import PdfFileWriter, PdfFileReader  # pylint: disable=W0404
+    from PyPDF2.utils import PdfReadError  # pylint: disable=W0404
+except ImportError:
+    pass
+try:
+    # we need this to be sure PIL has loaded PDF support
+    from PIL import PdfImagePlugin  # noqa: F401
+except ImportError:
+    pass
+from odoo import api, models, tools
 
 logger = getLogger(__name__)
 

--- a/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
+++ b/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # © 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from openerp.tests.common import TransactionCase
+from PIL import Image
+from openerp.tests.common import HttpCase
 
 
-class TestReportQwebPdfWatermark(TransactionCase):
+class TestReportQwebPdfWatermark(HttpCase):
     def test_report_qweb_pdf_watermark(self):
+        Image.init()
         # with our image, we have three
         self._test_report_images(3)
 

--- a/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
+++ b/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
@@ -2,7 +2,7 @@
 # © 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from PIL import Image
-from openerp.tests.common import HttpCase
+from odoo.tests.common import HttpCase
 
 
 class TestReportQwebPdfWatermark(HttpCase):

--- a/report_qweb_signer/tests/test_report_qweb_signer.py
+++ b/report_qweb_signer/tests/test_report_qweb_signer.py
@@ -2,20 +2,17 @@
 # Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp.tests import common
+from odoo.tests.common import HttpCase
 
 
-@common.at_install(False)
-@common.post_install(True)
-class TestReportQwebSigner(common.SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestReportQwebSigner, cls).setUpClass()
-        cls.partner = cls.env['res.partner'].create({
+class TestReportQwebSigner(HttpCase):
+    def setUp(self):
+        super(TestReportQwebSigner, self).setUp()
+        self.partner = self.env['res.partner'].create({
             'name': 'Test partner',
             'customer': True,
         })
-        cls.report = cls.env.ref('report_qweb_signer.partner_demo_report')
+        self.report = self.env.ref('report_qweb_signer.partner_demo_report')
 
     def test_report_qweb_signer(self):
         self.env['report'].get_pdf(


### PR DESCRIPTION
Forward port of past commits made by @hbrunn on the 9.0 branch:
https://github.com/OCA/reporting-engine/commit/c0252f7ce6bec407fcb5eadc814469562f866b7f
https://github.com/OCA/reporting-engine/commit/fcd1117331f8bbd9560d24798ef1aa05fa6acc77