### PR TITLE
10.0 py3o improvements

### DIFF
--- a/report_py3o/README.rst
+++ b/report_py3o/README.rst
@@ -240,6 +240,7 @@ Contributors
 * Laurent Mignon <laurent.mignon@acsone.eu>,
 * Alexis de Lattre <alexis.delattre@akretion.com>,
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Omar Castiñeira <omar@comunitea.com>
 
 
 Maintainer

--- a/report_py3o/__manifest__.py
+++ b/report_py3o/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Py3o Report Engine',
     'summary': 'Reporting engine based on Libreoffice (ODT -> ODT, '
                'ODT -> PDF, ODT -> DOC, ODT -> DOCX, ODS -> ODS, etc.)',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'category': 'Reporting',
     'license': 'AGPL-3',
     'author': 'XCG Consulting,'

--- a/report_py3o/models/ir_actions_report_xml.py
+++ b/report_py3o/models/ir_actions_report_xml.py
@@ -23,25 +23,26 @@ class IrActionsReportXml(models.Model):
 
     _inherit = 'ir.actions.report.xml'
 
-    @api.one
+    @api.multi
     @api.constrains("py3o_filetype", "report_type")
     def _check_py3o_filetype(self):
-        if self.report_type == "py3o" and not self.py3o_filetype:
-            raise ValidationError(_(
-                "Field 'Output Format' is required for Py3O report"))
+        for report in self:
+            if report.report_type == "py3o" and not report.py3o_filetype:
+                raise ValidationError(_(
+                    "Field 'Output Format' is required for Py3O report"))
 
-    @api.one
+    @api.multi
     @api.constrains("py3o_is_local_fusion", "py3o_server_id",
                     "py3o_filetype")
     def _check_py3o_server_id(self):
-        if self.report_type != "py3o":
-            return
-        is_native = Formats().get_format(self.py3o_filetype).native
-        if ((not is_native or not self.py3o_is_local_fusion) and
-                not self.py3o_server_id):
-            raise ValidationError(_(
-                "Can not use not native format in local fusion. "
-                "Please specify a Fusion Server"))
+        for report in self:
+            if report.report_type == "py3o":
+                is_native = Formats().get_format(report.py3o_filetype).native
+                if ((not is_native or not report.py3o_is_local_fusion) and
+                        not report.py3o_server_id):
+                    raise ValidationError(_(
+                        "Can not use not native format in local fusion. "
+                        "Please specify a Fusion Server"))
 
     @api.model
     def _get_py3o_filetypes(self):

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 from contextlib import closing
-from genshi.core import Markup
 
 import pkg_resources
 import requests
@@ -28,6 +27,7 @@ try:
     from py3o.template.helpers import Py3oConvertor
     from py3o.template import Template
     from py3o import formats
+    from genshi.core import Markup
 except ImportError:
     logger.debug('Cannot import py3o.template')
 try:

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 from contextlib import closing
+from genshi.core import Markup
 
 import pkg_resources
 import requests
@@ -64,12 +65,22 @@ def py3o_report_extender(report_xml_id=None):
     return fct1
 
 
+def format_multiline_value(value):
+    if value:
+        return Markup(unicode(value).replace('<', '&lt;').replace('>', '&gt;').
+                      replace('\n', '<text:line-break/>').
+                      replace('\t', '<text:s/><text:s/><text:s/><text:s/>'))
+    return ""
+
+
 @py3o_report_extender()
 def defautl_extend(report_xml, localcontext):
     # add the base64decode function to be able do decode binary fields into
     # the template
     localcontext['b64decode'] = b64decode
     localcontext['report_xml'] = report_xml
+    localcontext['format_multiline_value'] = format_multiline_value
+    localcontext['html_sanitize'] = tools.html2plaintext
 
 
 class Py3oReport(models.TransientModel):

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -67,7 +67,7 @@ def py3o_report_extender(report_xml_id=None):
 
 def format_multiline_value(value):
     if value:
-        return Markup(unicode(value).replace('<', '&lt;').replace('>', '&gt;').
+        return Markup(value.replace('<', '&lt;').replace('>', '&gt;').
                       replace('\n', '<text:line-break/>').
                       replace('\t', '<text:s/><text:s/><text:s/><text:s/>'))
     return ""


### PR DESCRIPTION
Hi,

Adds two new functions to report's context, one allows to interprete \n and \t chars in Odoo's strings and the other one cleans texts from html tags. Without this py3o doesn't respect carriage return in text field and print the html tags in the html fields of Odoo.

Regards