### PR TITLE
[FIX] report_qweb_signer: Remove hardcoded memory limits

### DIFF
--- a/report_qweb_signer/README.rst
+++ b/report_qweb_signer/README.rst
@@ -41,6 +41,16 @@ For example, if you want to sign only customer invoices in open or paid state:
 **Note**: Linux user that executes Odoo server process must have
 read access to certificate file and password file
 
+Java Memory Settings
+--------------------
+
+If you are signing large amounts of reports at the same time, or if you have a
+lower worker memory size than the JVM defaults, you may need to tune the JVM
+heap memory limits. Do so by adding a ``$JVM_ARGS`` environment variable that
+contains the required flags. Check out these links too:
+
+- `StackOverflow answer <https://stackoverflow.com/a/14763095/1468388>`_.
+- `Java docs <https://docs.oracle.com/cd/E15523_01/web.1111/e13814/jvm_tuning.htm#PERFM161>`_.
 
 Usage
 =====
@@ -100,6 +110,7 @@ Contributors
 * Rafael Blasco <rafael.blasco@tecnativa.com>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/report_qweb_signer/__manifest__.py
+++ b/report_qweb_signer/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Qweb PDF reports signer",
     "summary": "Sign Qweb PDFs usign a PKCS#12 certificate",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Reporting",
     "website": "https://www.tecnativa.com",
     "author": "Tecnativa, "

--- a/report_qweb_signer/models/report.py
+++ b/report_qweb_signer/models/report.py
@@ -108,7 +108,7 @@ class Report(models.Model):
 
     def _signer_bin(self, opts):
         me = os.path.dirname(__file__)
-        java_bin = 'java -jar -Xms4M -Xmx4M'
+        java_bin = 'java -jar'
         jar = '{}/../static/jar/jPdfSign.jar'.format(me)
         return '%s %s %s' % (java_bin, jar, opts)
 


### PR DESCRIPTION
These limits were being hit when printing PDF reports with just 80 pages.

Now it printed 500 pages with no hassle, just with default OpenJDK settings.

@Tecnativa