### PR TITLE
[10.0][FIX]report_py3o: Escape correctly html characters.

### DIFF
--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -7,6 +7,7 @@ from base64 import b64decode
 from cStringIO import StringIO
 import logging
 import os
+import cgi
 from contextlib import closing
 import subprocess
 
@@ -64,8 +65,7 @@ def py3o_report_extender(report_xml_id=None):
 
 def format_multiline_value(value):
     if value:
-        return Markup(value.replace('<', '&lt;').replace('>', '&gt;').
-                      replace('\n', '<text:line-break/>').
+        return Markup(cgi.escape(value).replace('\n', '<text:line-break/>').
                       replace('\t', '<text:s/><text:s/><text:s/><text:s/>'))
     return ""
 

--- a/report_py3o/tests/test_report_py3o.py
+++ b/report_py3o/tests/test_report_py3o.py
@@ -15,8 +15,16 @@ from odoo import tools
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError
 
-from ..models.py3o_report import TemplateNotFound
+from ..models.py3o_report import TemplateNotFound, format_multiline_value
 from base64 import b64encode
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from genshi.core import Markup
+except ImportError:
+    logger.debug('Cannot import genshi.core')
 
 
 @contextmanager
@@ -188,3 +196,7 @@ class TestReportPy3o(TransactionCase):
         # non exising files are not valid template
         self.assertFalse(self.py3o_report._get_template_from_path(
             '/etc/test.odt'))
+
+    def test_escape_html_characters_format_multiline_value(self):
+        self.assertEqual(Markup('&lt;&gt;<text:line-break/>&amp;test;'),
+                         format_multiline_value('<>\n&test;'))


### PR DESCRIPTION
The previous behavior fails when the string contained characters such as "&". And it chains many replace.