### PR TITLE
[FIX] unlink rule before model

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -176,6 +176,8 @@ class BiSQLView(models.Model):
     @api.multi
     def button_set_draft(self):
         for sql_view in self:
+            sql_view.rule_id.unlink()
+
             if sql_view.state in ('model_valid', 'ui_valid'):
                 # Drop SQL View (and indexes by cascade)
                 sql_view._drop_view()
@@ -186,7 +188,6 @@ class BiSQLView(models.Model):
             sql_view.graph_view_id.unlink()
             sql_view.action_id.unlink()
             sql_view.menu_id.unlink()
-            sql_view.rule_id.unlink()
             if sql_view.cron_id:
                 sql_view.cron_id.unlink()
             sql_view.write({'state': 'draft', 'has_group_changed': False})

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -141,7 +141,7 @@ class BiSQLView(models.Model):
             ('state', 'not in', ('draft', 'sql_valid'))])
         if non_draft_views:
             raise UserError(_("You can only unlink draft views"))
-        return self.unlink()
+        return super(BiSQLView, self).unlink()
 
     @api.multi
     def copy(self, default=None):


### PR DESCRIPTION
If model is created, unlinking rule is not possible because the rule has a required field to the model.

This PR change the order of the deletion

++ calling super, avoiding infinite loop.

CC : @jbeficent, @aheficent, @nicomacr

regards.