### PR TITLE
[10.0][FIX] bi_view_editor: bugfixing

### DIFF
--- a/bi_view_editor/__manifest__.py
+++ b/bi_view_editor/__manifest__.py
@@ -10,7 +10,7 @@
     'license': 'AGPL-3',
     'website': 'http://www.onestein.eu',
     'category': 'Reporting',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'depends': [
         'base',
         'web'

--- a/bi_view_editor/models/models.py
+++ b/bi_view_editor/models/models.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, models
-from odoo.exceptions import Warning as UserError
+from odoo.exceptions import UserError
 from odoo.tools.translate import _
 
 

--- a/bi_view_editor/tests/test_bi_view.py
+++ b/bi_view_editor/tests/test_bi_view.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase, at_install, post_install
-from odoo.exceptions import Warning as UserError
+from odoo.exceptions import UserError
 
 
 class TestBiViewEditor(TransactionCase):


### PR DESCRIPTION
This PR does the following:

- [x] Avoid occasional error while deleting Custom BI Views: fixes https://github.com/OCA/reporting-engine/issues/158
- [x] Does not crash when selection fields are defined by function
- [x] Does not stuck when user double-clicks
- [x] Fixes the deletion of the items from the widget (only the last one could be deleted)
- [x] Adds js robustness
- [x] Fix some pylint warnings