### PR TITLE
[FIX] Don't break printing some upstream reports with invalid models

### DIFF
--- a/report_qweb_pdf_watermark/__manifest__.py
+++ b/report_qweb_pdf_watermark/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Pdf watermark",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "author": "Therp BV, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/report_qweb_pdf_watermark/models/report.py
+++ b/report_qweb_pdf_watermark/models/report.py
@@ -34,9 +34,9 @@ class Report(models.Model):
         watermark = None
         if report.pdf_watermark:
             watermark = b64decode(report.pdf_watermark)
-        else:
+        elif report.pdf_watermark_expression:
             watermark = tools.safe_eval(
-                report.pdf_watermark_expression or 'None',
+                report.pdf_watermark_expression,
                 dict(env=self.env, docs=self.env[report.model].browse(docids)),
             )
             if watermark:


### PR DESCRIPTION
When no background configuration is present on the report definition,
don't try to browse the report model especially because this breaks
some upstream reports (see https://github.com/odoo/odoo/pull/23389)