### PR TITLE
[IMP] report_fillpdf, report_xlsx, report_xml: Use content_disposition helper

### DIFF
--- a/report_fillpdf/__manifest__.py
+++ b/report_fillpdf/__manifest__.py
@@ -9,7 +9,7 @@
               'Odoo Community Association (OCA)',
     'website': "http://github.com/oca/reporting-engine",
     'category': 'Reporting',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'license': 'AGPL-3',
     'external_dependencies': {
         'python': [

--- a/report_fillpdf/controllers/main.py
+++ b/report_fillpdf/controllers/main.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
 
 from odoo.addons.web.controllers import main as report
-from odoo.http import route, request
+from odoo.http import content_disposition, route, request
 
 import json
 
@@ -34,7 +34,7 @@ class ReportController(report.ReportController):
                 ('Content-Length', len(pdf)),
                 (
                     'Content-Disposition',
-                    'attachment; filename=' + report.report_file + '.pdf'
+                    content_disposition(report.report_file + '.pdf')
                 )
             ]
             return request.make_response(pdf, headers=pdfhttpheaders)

--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -10,7 +10,7 @@
               'Odoo Community Association (OCA)',
     'website': "http://github.com/oca/reporting-engine",
     'category': 'Reporting',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'license': 'AGPL-3',
     'external_dependencies': {
         'python': [

--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
 
 from odoo.addons.web.controllers import main as report
-from odoo.http import route, request
+from odoo.http import content_disposition, route, request
 
 import json
 
@@ -35,7 +35,7 @@ class ReportController(report.ReportController):
                 ('Content-Length', len(xlsx)),
                 (
                     'Content-Disposition',
-                    'attachment; filename=' + report.report_file + '.xlsx'
+                    content_disposition(report.report_file + '.xlsx')
                 )
             ]
             return request.make_response(xlsx, headers=xlsxhttpheaders)

--- a/report_xml/__manifest__.py
+++ b/report_xml/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "XML Reports",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Reporting",
     "website": "https://github.com/OCA/reporting-engine",
     "author": "Grupo ESOC Ingeniería de Servicios, "

--- a/report_xml/controllers/main.py
+++ b/report_xml/controllers/main.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
 
 from odoo.addons.web.controllers import main as report
-from odoo.http import route
+from odoo.http import content_disposition, route
 
 
 class ReportController(report.ReportController):
@@ -23,5 +23,5 @@ class ReportController(report.ReportController):
             response.headers.set('Content-length', len(response.data))
             response.headers.set(
                 'Content-Disposition',
-                'attachment; filename="'+reportname+".xml")
+                content_disposition(reportname + ".xml"))
         return response


### PR DESCRIPTION
Reasoning:
- safer ([uses percent encoding](https://github.com/odoo/odoo/blob/350973ff36619bec129a3dace312ec0ae561c55e/odoo/http.py#L1632));
- handles [some browser quirks](https://github.com/odoo/odoo/blob/350973ff36619bec129a3dace312ec0ae561c55e/odoo/http.py#L1635-L1640);
- if some improvements are made to the `content_disposition` function in the future, one would get the benefits for free.