### PR TITLE
[9.0][bi_sql_editor] default number of calls of ir.cron to -1 by default.

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -294,6 +294,7 @@ class BiSQLView(models.Model):
             'user_id': SUPERUSER_ID,
             'model': 'bi.sql.view',
             'function': 'button_refresh_materialized_view',
+            'numbercall': -1,
             'args': repr(([self.id],))
         }
 


### PR DESCRIPTION
Now, when you create a materialized view using the bi_sql_editor, it creates by default an ir.cron. However this cron is created with default parameters, including number of calls = 1, which basically means that the report is going to be executed just once.

I think that it is better to default to -1, and leave the default proposal for the periodicity (every month).

That is going to ensure that at least the materialized view will be refreshed EVERY month.

This is important, considering that putting -1 is not evident to users, and considering that when one creates a materialized view it is assumed that you will want it to be refreshed automatically.

@legalsylvain do you agree?
@p-tombez you are migrating the module to v11 (https://github.com/OCA/reporting-engine/pull/206), so you should be aware of this.