### PR TITLE
[IMP] check for template data, not for the id

### DIFF
--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -175,7 +175,7 @@ class Py3oReport(models.TransientModel):
         """
         self.ensure_one()
         report_xml = self.ir_actions_report_xml_id
-        if report_xml.py3o_template_id and report_xml.py3o_template_id.id:
+        if report_xml.py3o_template_id.py3o_template_data:
             # if a user gave a report template
             tmpl_data = b64decode(
                 report_xml.py3o_template_id.py3o_template_data


### PR DESCRIPTION
we should check if a template actually has data, given the binary field is not required: https://github.com/hbrunn/reporting-engine/blob/12be6cbca8895514e0cc63ad012876f9e0ec67e3/report_py3o/models/py3o_template.py#L11