### PR TITLE
[FIX] Javascript definition name was duplicated

### DIFF
--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -3,14 +3,13 @@
 {
     'name': "Base report xlsx",
 
-    'summary': """
-        Base module to create xlsx report""",
+    'summary': "Base module to create xlsx report",
     'author': 'ACSONE SA/NV,'
               'Creu Blanca,'
               'Odoo Community Association (OCA)',
     'website': "http://github.com/oca/reporting-engine",
     'category': 'Reporting',
-    'version': '11.0.1.0.1',
+    'version': '11.0.1.0.2',
     'license': 'AGPL-3',
     'external_dependencies': {
         'python': [

--- a/report_xlsx/static/src/js/report/qwebactionmanager.js
+++ b/report_xlsx/static/src/js/report/qwebactionmanager.js
@@ -1,6 +1,6 @@
 // © 2017 Creu Blanca
 // License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
-odoo.define('report_xml.report', function(require){
+odoo.define('report_xlsx.report', function(require){
 'use strict';
 
 var ActionManager= require('web.ActionManager');


### PR DESCRIPTION
Javascript function name was duplicated and was giving problem when `report_xlsx` and `report_xml` where both installed.