### PR TITLE
Fix report_xlsx for printing from wizards

### DIFF
--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -7,9 +7,9 @@
     'author': 'ACSONE SA/NV,'
               'Creu Blanca,'
               'Odoo Community Association (OCA)',
-    'website': "http://github.com/oca/reporting-engine",
+    'website': "https://github.com/oca/reporting-engine",
     'category': 'Reporting',
-    'version': '11.0.1.0.2',
+    'version': '11.0.1.0.3',
     'license': 'AGPL-3',
     'external_dependencies': {
         'python': [

--- a/report_xlsx/report/report_xlsx.py
+++ b/report_xlsx/report/report_xlsx.py
@@ -17,8 +17,30 @@ except ImportError:
 class ReportXlsxAbstract(models.AbstractModel):
     _name = 'report.report_xlsx.abstract'
 
+    def _get_objs_for_report(self, docids, data):
+        """
+        Returns objects for xlx report.  From WebUI these
+        are either as docids taken from context.active_ids or
+        in the case of wizard are in data.  Manual calls may rely
+        on regular context, setting docids, or setting data.
+
+        :param docids: list of integers, typically provided by
+            qwebactionmanager for regular Models.
+        :param data: dictionary of data, if present typically provided
+            by qwebactionmanager for TransientModels.
+        :param ids: list of integers, provided by overrides.
+        :return: recordset of active model for ids.
+        """
+        if docids:
+            ids = docids
+        elif data and 'context' in data:
+            ids = data["context"].get('active_ids', [])
+        else:
+            ids = self.env.context.get('active_ids', [])
+        return self.env[self.env.context.get('active_model')].browse(ids)
+
     def create_xlsx_report(self, docids, data):
-        objs = self.env[self.env.context.get('active_model')].browse(docids)
+        objs = self._get_objs_for_report(docids, data)
         file_data = BytesIO()
         workbook = xlsxwriter.Workbook(file_data, self.get_workbook_options())
         self.generate_xlsx_report(workbook, data, objs)
@@ -27,6 +49,10 @@ class ReportXlsxAbstract(models.AbstractModel):
         return file_data.read(), 'xlsx'
 
     def get_workbook_options(self):
+        """
+        See https://xlsxwriter.readthedocs.io/workbook.html constructor options
+        :return: A dictionary of options
+        """
         return {}
 
     def generate_xlsx_report(self, workbook, data, objs):

--- a/report_xlsx/static/src/js/report/qwebactionmanager.js
+++ b/report_xlsx/static/src/js/report/qwebactionmanager.js
@@ -14,9 +14,14 @@ ActionManager.include({
         if (cloned_action.report_type === 'xlsx') {
             framework.blockUI();
             var report_xlsx_url = 'report/xlsx/' + cloned_action.report_name;
-            if(cloned_action.context.active_ids){
-                report_xlsx_url += '/' + cloned_action.context.active_ids.join(',');
-            }else{
+            if (_.isUndefined(cloned_action.data) ||
+                _.isNull(cloned_action.data) ||
+                (_.isObject(cloned_action.data) && _.isEmpty(cloned_action.data)))
+            {
+                if(cloned_action.context.active_ids) {
+                    report_xlsx_url += '/' + cloned_action.context.active_ids.join(',');
+                }
+            } else {
                 report_xlsx_url += '?options=' + encodeURIComponent(JSON.stringify(cloned_action.data));
                 report_xlsx_url += '&context=' + encodeURIComponent(JSON.stringify(cloned_action.context));
             }

--- a/report_xlsx/tests/test_report.py
+++ b/report_xlsx/tests/test_report.py
@@ -12,13 +12,44 @@ except ImportError:
 
 
 class TestReport(common.TransactionCase):
-    def test_report(self):
+    def setUp(self):
+        super(TestReport, self).setUp()
         report_object = self.env['ir.actions.report']
-        report_name = 'report_xlsx.partner_xlsx'
-        report = report_object._get_report_from_name(report_name)
-        docs = self.env['res.company'].search([], limit=1).partner_id
+        self.xlsx_report = (
+            self.env['report.report_xlsx.abstract']
+            .with_context(active_model='res.partner')
+        )
+        self.report_name = 'report_xlsx.partner_xlsx'
+        self.report = report_object._get_report_from_name(self.report_name)
+        self.docs = self.env['res.company'].search([], limit=1).partner_id
+
+    def test_report(self):
+        report = self.report
         self.assertEqual(report.report_type, 'xlsx')
-        rep = report.render(docs.ids, {})
+        rep = report.render(self.docs.ids, {})
         wb = open_workbook(file_contents=rep[0])
         sheet = wb.sheet_by_index(0)
-        self.assertEqual(sheet.cell(0, 0).value, docs.name)
+        self.assertEqual(sheet.cell(0, 0).value, self.docs.name)
+
+    def test_id_retrieval(self):
+
+        # Typical call from WebUI with wizard
+        objs = self.xlsx_report._get_objs_for_report(
+            False, {"context": {"active_ids": self.docs.ids}})
+        self.assertEquals(objs, self.docs)
+
+        # Typical call from within code not to report_action
+        objs = self.xlsx_report.with_context(
+            active_ids=self.docs.ids)._get_objs_for_report(False, False)
+        self.assertEquals(objs, self.docs)
+
+        # Typical call from WebUI
+        objs = self.xlsx_report._get_objs_for_report(
+            self.docs.ids,
+            {"data": [self.report_name, self.report.report_type]}
+        )
+        self.assertEquals(objs, self.docs)
+
+        # Typical call from render
+        objs = self.xlsx_report._get_objs_for_report(self.docs.ids, {})
+        self.assertEquals(objs, self.docs)


### PR DESCRIPTION
Resolves #237 by checking for data first in calling action typically `report_action` from wizard button.

Note report_xml will need the same fix for at least qwebactionmanager.js