### PR TITLE
[11.0] fix oca_dependencies

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,1 @@
-server-tools https://github.com/Eficent/server-tools.git 11.0-mig-sql_request_abstract
+server-tools


### PR DESCRIPTION
Removes an oca dependency to a PR that is not required anymore.