### PR TITLE
[10.0][FIX]fix _render for cell formats

### DIFF
--- a/report_xlsx_helper/report/abstract_report_xlsx.py
+++ b/report_xlsx_helper/report/abstract_report_xlsx.py
@@ -529,6 +529,8 @@ class AbstractReportXlsx(ReportXlsx):
             args_pos = [row_pos, pos]
             args_data = [cell_value]
             if cell_format:
+                if isinstance(cell_format, CodeType):
+                    cell_format = self._eval(cell_format, render_space)
                 args_data.append(cell_format)
             if colspan > 1:
                 args_pos += [row_pos, pos + colspan - 1]


### PR DESCRIPTION
Fix self._render usage in the 'format' of the excel template.

Cf. https://github.com/luc-demeyer/noviat-apps/tree/10.0/stock_level_export_xls
for a concrete case where this is used.
