### PR TITLE
[ADD] Module report_controller

### DIFF
--- a/report_controller/README.rst
+++ b/report_controller/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================
+Report Controller
+=====================
+
+This modules brings back the controller type for reports missing since Odoo 11.0
+
+
+Usage
+=====
+
+#. Add a t-length attribute on report templates fields that will truncate the field
+#. Add a t-minlength attribute on report template fields that will check the min length
+#. Add a t-maxlength attribute on report template fields that will check the max length
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/143/11.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/reporting-engine/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Hugo Rodrigues <me@hugorodrigues.net>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/report_controller/README.rst
+++ b/report_controller/README.rst
@@ -7,14 +7,15 @@ Report Controller
 =====================
 
 This modules brings back the controller type for reports missing since Odoo 11.0
+The goal of this module is to print data from 3rd party services. For example,
+in Portugal only a certified software can print customer invoices, and since
+only Odoo SA is the only one that can certify Odoo, the certification happens
+outside Odoo. Using a controller report, the user can print the certified PDF
+using the print menu.
 
 
 Usage
 =====
-
-#. Add a t-length attribute on report templates fields that will truncate the field
-#. Add a t-minlength attribute on report template fields that will check the min length
-#. Add a t-maxlength attribute on report template fields that will check the max length
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/report_controller/__init__.py
+++ b/report_controller/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import controllers
+from . import models

--- a/report_controller/__manifest__.py
+++ b/report_controller/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2018 Hugo Rodrigues
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Report Controller",
+    "version": "12.0.1.0.0",
+    "license": "AGPL-3",
+    "summany": """
+        Reimplement controller type controllers, missing since Odoo 11.0
+    """,
+    "author": "Hugo Rodrigues, Odoo Community Association (OCA)",
+    "website": "https://github.com/oca/reporting-engine",
+    "category": "Technical Settings",
+    "depends": ["web"],
+    "data": [
+        "views/assets.xml",
+        "views/ir_actions_report_view.xml"
+        ]
+}

--- a/report_controller/controllers/__init__.py
+++ b/report_controller/controllers/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import main

--- a/report_controller/controllers/main.py
+++ b/report_controller/controllers/main.py
@@ -85,7 +85,7 @@ class Report(ReportController):
                     data = url_decode(url.split("?")[1]).items()
                     response = self.report_routes(reportname,
                                                   converter="controller",
-                                                 **dict(data))
+                                                  **dict(data))
                 report = report_obj._get_report_from_name(reportname)
                 filename = "%s.pdf" % (report.name)
 

--- a/report_controller/controllers/main.py
+++ b/report_controller/controllers/main.py
@@ -1,0 +1,103 @@
+# Copyright 2018 Hugo Rodrigues
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import json
+
+from werkzeug.urls import url_decode
+
+
+from odoo.tools import html_escape
+from odoo.tools.safe_eval import safe_eval
+from odoo.http import request, route, serialize_exception, content_disposition
+from odoo.addons.web.controllers.main import ReportController
+from ..models.ir_actions_report import CONTROLLER_KEYS
+
+class Report(ReportController):
+
+
+    @route()
+    def report_routes(self, reportname, docids=None, converter=None, **data):
+        """
+        Extends de base controller to download controller reports
+        """
+        if converter not in CONTROLLER_KEYS:
+            return super(Report, self).report_routes(reportname, docids=docids,
+                                                     converter=converter,
+                                                     **data)
+        report = request.env['ir.actions.report']._get_report_from_name(reportname)
+        context = dict(request.env.context)
+
+        if docids:
+            docids = [int(i) for i in docids.split(',')]
+        if data.get('options'):
+            data.update(json.loads(data.pop('options')))
+        if data.get('context'):
+            # Ignore 'lang' here, because the context in data is the one from the webclient *but* if
+            # the user explicitely wants to change the lang, this mechanism overwrites it.
+            data['context'] = json.loads(data['context'])
+            if data['context'].get('lang'):
+                del data['context']['lang']
+            context.update(data['context'])
+
+        if converter == 'controller':
+            pdf = report.with_context(context).render_controller(docids,
+                                                                 data=data)[0]
+            pdfhttpheaders = [('Content-Type', 'application/pdf'), ('Content-Length', len(pdf))]
+            return request.make_response(pdf, headers=pdfhttpheaders)
+        else:
+            raise werkzeug.exceptions.HTTPException(description='Converter %s not implemented.' % converter)
+
+    @route()
+    def report_download(self, data, token):
+        """
+        Extends de base controller to download controller reports
+        
+        :param data: a javascript array JSON.stringified containg
+                     report internal url ([0]) and type [1]
+        :returns: Response with a filetoken cookie and an attachment heade
+        """
+        rcontent = json.loads(data)
+        url, rtype = rcontent[0], rcontent[1]
+        # Return error as upstream
+        try:
+            if rtype not in CONTROLLER_KEYS:
+                return super(Report, self).report_download(data, token)
+            if rtype == "controller":
+                # Based on upstream
+                # addons/web/controllers/main.py:1649
+                reportname = url.split("/report/controller/")[1].split("?")[0]
+                docids = None
+                if "/" in reportname:
+                    reportname, docids = reportname.split("/")
+
+                if docids:
+                    response = self.report_routes(reportname, docids=docids,
+                                                  converter="controller")
+                else:
+                    data = url_decode(url.split("?")[1]).items()
+                    reponse = self.report_routes(reportname,
+                                                 converter=converter,
+                                                 **dict(data))
+                report = request.env["ir.actions.report"]._get_report_from_name(reportname)
+                filename = "%s.pdf" % (report.name)
+
+                if docids:
+                    ids = [int(x) for x in docids.split(",")]
+                    obj = request.env[report.model].browse(ids)
+                    if report.print_report_name and not len(obj) > 1:
+                        report_name = safe_eval(report.print_report_name,
+                                                {"object": obj, "time": time})
+                        filename = "%s.%s" % (report_name, extension)
+                response.headers.add("Content-Disposition",
+                                     content_disposition(filename))
+                response.set_cookie("fileToken", token)
+                return response
+            return
+        except Exception as e:
+            se = serialize_exception(e)
+            error = {
+                "code": 200,
+                "message": "Odoo Server Error",
+                "data": se
+                }
+            return request.make_response(html_escape(json.dumps(error)))

--- a/report_controller/i18n/pt.po
+++ b/report_controller/i18n/pt.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-24 15:23+0000\n"
-"PO-Revision-Date: 2019-06-24 15:23+0000\n"
+"POT-Creation-Date: 2019-06-25 09:21+0000\n"
+"PO-Revision-Date: 2019-06-25 09:21+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,7 +17,28 @@ msgstr ""
 
 #. module: report_controller
 #: code:addons/report_controller/models/ir_actions_report.py:0
-#: sql_constraint:ir.actions.report:0
+#, python-format
+msgid "400 Bad Request:\n"
+"%s"
+msgstr "400 Pedido mal Formado:\n"
+"%s"
+
+#. module: report_controller
+#: code:addons/report_controller/models/ir_actions_report.py:0
+#, python-format
+msgid "404 Page not Found"
+msgstr "404 Página não Encontrada"
+
+#. module: report_controller
+#: code:addons/report_controller/models/ir_actions_report.py:0
+#, python-format
+msgid "500 Internal Server Error:\n"
+"%s"
+msgstr "500 Erro de Servidor Interno:\n"
+"%s"
+
+#. module: report_controller
+#: code:addons/report_controller/models/ir_actions_report.py:0
 #, python-format
 msgid "A controller report must have a URL"
 msgstr "Um relatório tipo controller tem de ter URL"

--- a/report_controller/i18n/pt.po
+++ b/report_controller/i18n/pt.po
@@ -1,0 +1,125 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* report_controller
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-06-24 15:23+0000\n"
+"PO-Revision-Date: 2019-06-24 15:23+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: report_controller
+#: code:addons/report_controller/models/ir_actions_report.py:0
+#: sql_constraint:ir.actions.report:0
+#, python-format
+msgid "A controller report must have a URL"
+msgstr "Um relatório tipo controller tem de ter URL"
+
+#. module: report_controller
+#. openerp-web
+#: code:addons/report_controller/static/src/js/qwebactionmanager.js:53
+#, python-format
+msgid "A popup window with your report was blocked. You may need to change your browser settings to allow popup windows for this page."
+msgstr "Uma janela popup com o seu relatório foi bloqueado. Poderás ter que mudar as configurações do teu browser para permitir janelas popup para esta página."
+
+#. module: report_controller
+#: model:ir.model.fields,field_description:report_controller.field_ir_actions_report__controller_content_type
+msgid "Content Type"
+msgstr "Tipo Conteudo"
+
+#. module: report_controller
+#: selection:ir.actions.report,report_type:0
+msgid "Controller"
+msgstr "Controlador"
+
+#. module: report_controller
+#: model:ir.model.fields,field_description:report_controller.field_ir_actions_report__controller_url
+msgid "Controller URL"
+msgstr "URL Controlador"
+
+#. module: report_controller
+#: model:ir.model.fields,help:report_controller.field_ir_actions_report__controller_url
+msgid "Controller from url to fetch. You can use a python expression with the 'object' and 'time' variables."
+msgstr "URL para buscar o controlador. Tu podes usar expressão python com variáveis 'object' e 'time'"
+
+#. module: report_controller
+#: code:addons/report_controller/models/ir_actions_report.py:0
+#, python-format
+msgid "Controller has no document type!"
+msgstr "Controlador não tem tipo de documento!"
+
+#. module: report_controller
+#: model:ir.model.fields,help:report_controller.field_ir_actions_report__controller_content_type
+msgid "Controller request content type."
+msgstr "Tipo de conteudo de pedido de controlador."
+
+#. module: report_controller
+#: code:addons/report_controller/models/ir_actions_report.py:0
+#, python-format
+msgid "Controller result isn't a PDF"
+msgstr "Resultado de controlador não é PDF"
+
+#. module: report_controller
+#: model:ir.model.fields,field_description:report_controller.field_ir_actions_report__controller_document_type
+msgid "Document Type"
+msgstr "Tipo de Documento"
+
+#. module: report_controller
+#: model_terms:ir.ui.view,arch_db:report_controller.ir_actions_report_form
+msgid "Example: '/res.partner/%s' % object.ids"
+msgstr "Exemplo: '/res.partner/%s' % object.ids"
+
+#. module: report_controller
+#: selection:ir.actions.report,controller_content_type:0
+msgid "Form"
+msgstr ""
+
+#. module: report_controller
+#: selection:ir.actions.report,report_type:0
+msgid "HTML"
+msgstr ""
+
+#. module: report_controller
+#: selection:ir.actions.report,controller_content_type:0
+msgid "JSON"
+msgstr ""
+
+#. module: report_controller
+#: selection:ir.actions.report,report_type:0
+msgid "PDF"
+msgstr ""
+
+#. module: report_controller
+#: model:ir.model.fields,field_description:report_controller.field_ir_actions_report__report_type
+msgid "Report Type"
+msgstr "Tipo de Relatório"
+
+#. module: report_controller
+#: selection:ir.actions.report,report_type:0
+msgid "Text"
+msgstr "Texto"
+
+#. module: report_controller
+#: model:ir.model.fields,help:report_controller.field_ir_actions_report__report_type
+msgid "The type of the report that will be rendered, each one having its own rendering method. HTML means the report will be opened directly in your browser PDF means the report will be rendered using Wkhtmltopdf and downloaded by the user Controller means the it will be use a controller or url and download the report from another origin."
+msgstr "O tipo de o relatório que será desenhado, cada um com o seu método de desenho. HTML siginifica que o relatório será aberto directamente no teu browser PDF significa que o relatório será desenhado usando Wkhtmltopdf e baixado pelo utilizador Controlador significa que será um controller ou url a buscar o relatório de outra origem."
+
+#. module: report_controller
+#. openerp-web
+#: code:addons/report_controller/static/src/js/qwebactionmanager.js:57
+#, python-format
+msgid "Warning"
+msgstr "Aviso"
+
+#. module: report_controller
+#: model_terms:ir.ui.view,arch_db:report_controller.ir_actions_report_form
+msgid "pdf"
+msgstr "pdf"
+

--- a/report_controller/models/__init__.py
+++ b/report_controller/models/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import ir_actions_report

--- a/report_controller/models/ir_actions_report.py
+++ b/report_controller/models/ir_actions_report.py
@@ -14,8 +14,8 @@ class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
     _sql_constraints = [
         ("check_controller_url",
-         "CHECK(report_type NOT ILIKE 'controller%' OR "\
-             "controller_url IS NOT NULL)",
+         "CHECK(report_type NOT ILIKE 'controller%' OR "
+         "controller_url IS NOT NULL)",
          _("A controller report must have a URL"))
     ]
 

--- a/report_controller/models/ir_actions_report.py
+++ b/report_controller/models/ir_actions_report.py
@@ -45,7 +45,7 @@ class IrActionsReport(models.Model):
     controller_content_type = fields.Selection(CONTENT_TYPES, "Content Type", help="Controller request content type.", default='multipart/form-data')
 
     controller_url = fields.Char("Controller URL", help="Controller from url to fetch. You can use a python expression with the 'object' and 'time' variables.")
-
+    
     #André Liu - Improvements To Do
     #Controller Data
     #Additional Controller header information
@@ -120,6 +120,8 @@ class IrActionsReport(models.Model):
         #Perhaps later we may wish to have other document types.
         if response.status_code == 404:
             raise exceptions.ValidationError(_('404 Page not Found'))
+        if response.status_code == 403:
+            raise exceptions.ValidationError(_('403 Forbidden:\n%s') % response.content)
         if response.status_code == 400:
             raise exceptions.ValidationError(_('400 Bad Request:\n%s') % response.content)
         if response.status_code == 500:

--- a/report_controller/models/ir_actions_report.py
+++ b/report_controller/models/ir_actions_report.py
@@ -9,10 +9,14 @@ CONTROLLER_KEYS = [x[0] for x in CONTROLLER_TYPES]
 
 PDF_MAGIC = b"%PDF"
 
+
 class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
     _sql_constraints = [
-        ("check_controller_url", "CHECK(report_type NOT ILIKE 'controller%' OR controller_url IS NOT NULL)", _("A controller report must have a URL"))
+        ("check_controller_url",
+         "CHECK(report_type NOT ILIKE 'controller%' OR "\
+             "controller_url IS NOT NULL)",
+         _("A controller report must have a URL"))
     ]
 
     report_type = fields.Selection(selection_add=CONTROLLER_TYPES)
@@ -37,5 +41,6 @@ class IrActionsReport(models.Model):
             url += docids
         response = requests.get(url)
         if response.content[:4] != PDF_MAGIC:
-            raise exceptions.ValidationError(_("Controller result isn't a PDF"))
+            error_msg = _("Controller result isn't a PDF")
+            raise exceptions.ValidationError(error_msg)
         return response.content, "pdf"

--- a/report_controller/models/ir_actions_report.py
+++ b/report_controller/models/ir_actions_report.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Hugo Rodrigues
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import requests
+from odoo import models, api, fields, _, exceptions
+
+CONTROLLER_TYPES = [("controller", "Controller")]
+CONTROLLER_KEYS = [x[0] for x in CONTROLLER_TYPES]
+
+PDF_MAGIC = b"%PDF"
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+    _sql_constraints = [
+        ("check_controller_url", "CHECK(report_type NOT ILIKE 'controller%' OR controller_url IS NOT NULL)", _("A controller report must have a URL"))
+    ]
+
+    report_type = fields.Selection(selection_add=CONTROLLER_TYPES)
+
+    controller_url = fields.Char()
+
+    @api.multi
+    def render_controller(self, res_ids, data=None):
+        """
+        This method gets the PDF report from a URL
+        """
+        self.ensure_one()
+        if not data:
+            data = {}
+
+        url = self.controller_url
+        if isinstance(res_ids, list) and \
+                all([isinstance(x, (int, str)) for x in res_ids]):
+            docids = ",".join([str(x) for x in res_ids])
+            if url[-1] != "/":
+                url += "/"
+            url += docids
+        response = requests.get(url)
+        if response.content[:4] != PDF_MAGIC:
+            raise exceptions.ValidationError(_("Controller result isn't a PDF"))
+        return response.content, "pdf"

--- a/report_controller/models/ir_actions_report.py
+++ b/report_controller/models/ir_actions_report.py
@@ -1,14 +1,23 @@
 # Copyright 2018 Hugo Rodrigues
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo import http, models, api, fields, tools, exceptions, _ 
+from werkzeug import urls
 import requests
-from odoo import models, api, fields, _, exceptions
+import datetime
+import functools
+import dateutil.relativedelta as relativedelta
+import copy
+import time
+from odoo.tools.safe_eval import safe_eval
 
 CONTROLLER_TYPES = [("controller", "Controller")]
 CONTROLLER_KEYS = [x[0] for x in CONTROLLER_TYPES]
 
 PDF_MAGIC = b"%PDF"
 
+CONTENT_TYPES = [('multipart/form-data', 'Form'),
+                 ('application/json', 'JSON')]
 
 class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
@@ -19,9 +28,19 @@ class IrActionsReport(models.Model):
          _("A controller report must have a URL"))
     ]
 
-    report_type = fields.Selection(selection_add=CONTROLLER_TYPES)
+    report_type = fields.Selection(selection_add=CONTROLLER_TYPES,
+                                   help="The type of the report that will be rendered, each one having its own rendering method. HTML means the report will be opened directly in your browser PDF means the report will be rendered using Wkhtmltopdf and downloaded by the user Controller means the it will be use a controller or url and download the report from another origin.")
+    controller_document_type = fields.Char("Document Type", default="pdf")
+    
+    #Destination Controller Content Type, in case controller wants json request
+    controller_content_type = fields.Selection(CONTENT_TYPES, "Content Type", help="Controller request content type.", default='multipart/form-data')
 
-    controller_url = fields.Char()
+    controller_url = fields.Char("Controller URL", help="Controller from url to fetch. You can use a python expression with the 'object' and 'time' variables.")
+
+    #André Liu - Improvements To Do
+    #Controller Data
+    #Additional Controller header information
+    #Allow different type of controllers
 
     @api.multi
     def render_controller(self, res_ids, data=None):
@@ -31,16 +50,66 @@ class IrActionsReport(models.Model):
         self.ensure_one()
         if not data:
             data = {}
+        #Controller report must have document type, default is pdf
+        if not self.controller_document_type:
+            raise exceptions.ValidationError(_("Controller has no document type!"))
 
         url = self.controller_url
+        
+        #Dict for constructing controller URL
+        localdict = {
+            'time': time
+        }
         if isinstance(res_ids, list) and \
                 all([isinstance(x, (int, str)) for x in res_ids]):
-            docids = ",".join([str(x) for x in res_ids])
-            if url[-1] != "/":
-                url += "/"
-            url += docids
-        response = requests.get(url)
+            docs = self.env[self.model].browse(res_ids)
+            localdict['object'] = docs
+        else:
+            localdict['object'] = self.env[self.model]
+            
+        #Rendering controller URL
+        url = safe_eval(url, localdict)
+        
+        #Append host if controller does not start with any of the following strings
+        add_host = True
+        for h in ['http://', 'https://', 'ftp://']:
+            if url.startswith(h):
+                add_host = False
+                break
+        if add_host:
+            #Append host
+            try:
+                host_url = http.request.httprequest.host_url
+            except:
+                host_url = self.sudo().env['ir.config_parameter'].get_param('web.base.url')
+            if host_url:
+                if not host_url.endswith('/'):
+                    host_url += '/'
+                while url.startswith('/'):
+                    url = url[1:]
+                url = host_url + url
+                
+        #Set Header and content type
+        headers = {
+            'Content-Type': self.controller_content_type,
+        }
+        try:
+            #Salvage session id cookie, allows for request to be recognized as the same session request
+            headers['cookie'] = 'session_id=%s;frontend_lang=%s' % (http.request.httprequest.cookies['session_id'], http.request.httprequest.cookies['frontend_lang'])
+        except:
+            pass
+        try:
+            #Added just in case it's lang dependent
+            headers['Accept-Language'] = http.request.httprequest.accept_languages.to_header()
+        except:
+            pass
+        
+        #Fetch document
+        response = requests.get(url, headers=headers)
+        
+        #Return error if not PDF
+        #Perhaps later we may wish to have other document types.
         if response.content[:4] != PDF_MAGIC:
             error_msg = _("Controller result isn't a PDF")
             raise exceptions.ValidationError(error_msg)
-        return response.content, "pdf"
+        return response.content, self.controller_document_type

--- a/report_controller/static/src/js/qwebactionmanager.js
+++ b/report_controller/static/src/js/qwebactionmanager.js
@@ -1,10 +1,10 @@
-// 2018 Hugo Rodrigues
+// 2018 Hugo Rodrigues, André Liu
 // License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
-var core = require('web.core');
-var _t = core._t;
 
 odoo.define("report_controller.report", function (require) {
     "use strict";
+    var core = require('web.core');
+    var _t = core._t;
 
     var ActionManager = require("web.ActionManager");
     var crash_manager = require("web.crash_manager");

--- a/report_controller/static/src/js/qwebactionmanager.js
+++ b/report_controller/static/src/js/qwebactionmanager.js
@@ -1,0 +1,94 @@
+// 2018 Hugo Rodrigues
+// License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
+odoo.define("report_controller.report", function(require){
+"use strict";
+
+var ActionManager = require("web.ActionManager");
+var crash_manager = require("web.crash_manager");
+var session = require("web.session");
+var framework = require("web.framework");
+
+var CONTROLLER_KEYS = ["controller"];
+
+ActionManager.include({
+    _triggerDownload: function (action, options, type) {
+        // Since _downloadReport doesn't have the report type, we must
+        // reimplement the method to be sure that is a controller report
+        // without breaking other modules
+        // If https://github.com/odoo/odoo/pull/28365 is merged and backported
+        // into 12.0, we don't need to reimplement nothing.
+        var self = this;
+        if (!CONTROLLER_KEYS.includes(type)) {
+            return self._super(action, options, type);
+        }
+        var reportUrls = self._makeReportUrls(action);
+        framework.blockUI();
+        var def = $.Deferred();
+        var blocked = !session.get_file({
+            url: "/report/download",
+            data: {
+                data: JSON.stringify([reportUrls[type], type]),
+            },
+            success: def.resolve.bind(def),
+            error: function () {
+                crash_manager.rpc_error.apply(crash_manager, arguments);
+                def.reject();
+            },
+            complete: framework.unblockUI,
+        });
+        if (blocked) {
+            var message = _t('A popup window with your report was blocked. You ' +
+                             'may need to change your browser settings to allow ' +
+                             'popup windows for this page.');
+            this.do_warn(_t('Warning'), message, true);
+        }
+        return def.then(function () {
+            if (action.close_on_report_download) {
+                return self.doAction({type: "ir.actions.act_window_close"},
+                                     _.pick(options, "on_close"));
+            } else {
+                return options.on_close();
+            }
+        });
+    },
+
+    _executeReportAction: function (action, options){
+        var self = this;
+        if (!CONTROLLER_KEYS.includes(action.report_type)) {
+            return self._super(action, options);
+        }
+        return self._triggerDownload(action, options, action.report_type);
+    },
+
+    _makeReportUrls: function (action) {
+        var self = this;
+        var res = self._super(action);
+
+        var reportUrls = {}
+
+        $.each(CONTROLLER_KEYS, function(index, type) {
+            reportUrls[type] = "/report/controller/" + action.report_name;
+        });
+
+        // Reimplement upstream url generation
+        // check web/static/src/js/chrome/action_manager_report.js:180
+        if (_.isUndefined(action.data) || _.isNull(action.data) ||
+            (_.isObject(action.data) && _.isEmpty(action.data))) {
+            if (action.context.active_ids) {
+                var activeIDsPath = "/" + action.context.active_ids.join(',');
+                _.mapObject(reportUrls, function (value, type) {
+                    res[type] = value + activeIDsPath;
+                });
+            }
+        } else {
+            var serializedOptionsPath = '?options=' + encodeURIComponent(JSON.stringify(action.data));
+            serializedOptionsPath += '&context=' + encodeURIComponent(JSON.stringify(action.context));
+            _.mapObject(reportUrls, function (value, type) {
+                res[type] = value + serializedOptionsPath;
+            });
+        }
+
+        return res;
+    }
+});
+});

--- a/report_controller/static/src/js/qwebactionmanager.js
+++ b/report_controller/static/src/js/qwebactionmanager.js
@@ -1,5 +1,8 @@
 // 2018 Hugo Rodrigues
 // License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
+var core = require('web.core');
+var _t = core._t;
+
 odoo.define("report_controller.report", function (require) {
     "use strict";
 
@@ -15,7 +18,8 @@ odoo.define("report_controller.report", function (require) {
          * Triggers the download of the report
          * @param {Object} action - the description of the action to execute
          * @param {Object} options - @see doAction for details
-         * @param {Deferred} resolved when the action has been executed
+         * @param {string} type -  Type of report
+         * @returns {Deferred} resolved when the action has been executed
          */
         _triggerDownload: function (action, options, type) {
             // Since _downloadReport doesn't have the report type, we must
@@ -36,6 +40,9 @@ odoo.define("report_controller.report", function (require) {
                     data: JSON.stringify([reportUrls[type], type]),
                 },
                 success: def.resolve.bind(def),
+                /**
+                 * Shows error raised by controller
+                 */
                 error: function () {
                     crash_manager.rpc_error.apply(crash_manager, arguments);
                     def.reject();
@@ -44,9 +51,9 @@ odoo.define("report_controller.report", function (require) {
             });
             if (blocked) {
                 var message = _t('A popup window with your report was ' +
-                                 'blocked. You may need to change your ' +
-                                 'browser settings to allow popup windows ' +
-                                 'for this page.');
+                        'blocked. You may need to change your ' +
+                        'browser settings to allow popup windows ' +
+                        'for this page.');
                 this.do_warn(_t('Warning'), message, true);
             }
             return def.then(function () {
@@ -91,7 +98,7 @@ odoo.define("report_controller.report", function (require) {
             });
 
             // Reimplement upstream url generation
-            // check web/static/src/js/chrome/action_manager_report.js:180
+            // Check web/static/src/js/chrome/action_manager_report.js:180
             if (_.isUndefined(action.data) || _.isNull(action.data) ||
                 _.isObject(action.data) && _.isEmpty(action.data)) {
                 if (action.context.active_ids) {
@@ -102,11 +109,11 @@ odoo.define("report_controller.report", function (require) {
                     });
                 }
             } else {
-                // encoded data and context
+                // Encoded data and context
                 var edata = encodeURIComponent(JSON.stringify(action.data));
                 var ecxt = encodeURIComponent(JSON.stringify(action.context));
-                var serializedOptionsPath = '?options=' + edata
-                serializedOptionsPath += '&context=' + ecxt
+                var serializedOptionsPath = '?options=' + edata;
+                serializedOptionsPath += '&context=' + ecxt;
                 _.mapObject(reportUrls, function (value, type) {
                     res[type] = value + serializedOptionsPath;
                 });

--- a/report_controller/static/src/js/qwebactionmanager.js
+++ b/report_controller/static/src/js/qwebactionmanager.js
@@ -1,94 +1,118 @@
 // 2018 Hugo Rodrigues
 // License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
-odoo.define("report_controller.report", function(require){
-"use strict";
+odoo.define("report_controller.report", function (require) {
+    "use strict";
 
-var ActionManager = require("web.ActionManager");
-var crash_manager = require("web.crash_manager");
-var session = require("web.session");
-var framework = require("web.framework");
+    var ActionManager = require("web.ActionManager");
+    var crash_manager = require("web.crash_manager");
+    var session = require("web.session");
+    var framework = require("web.framework");
 
-var CONTROLLER_KEYS = ["controller"];
+    var CONTROLLER_KEYS = ["controller"];
 
-ActionManager.include({
-    _triggerDownload: function (action, options, type) {
-        // Since _downloadReport doesn't have the report type, we must
-        // reimplement the method to be sure that is a controller report
-        // without breaking other modules
-        // If https://github.com/odoo/odoo/pull/28365 is merged and backported
-        // into 12.0, we don't need to reimplement nothing.
-        var self = this;
-        if (!CONTROLLER_KEYS.includes(type)) {
-            return self._super(action, options, type);
-        }
-        var reportUrls = self._makeReportUrls(action);
-        framework.blockUI();
-        var def = $.Deferred();
-        var blocked = !session.get_file({
-            url: "/report/download",
-            data: {
-                data: JSON.stringify([reportUrls[type], type]),
-            },
-            success: def.resolve.bind(def),
-            error: function () {
-                crash_manager.rpc_error.apply(crash_manager, arguments);
-                def.reject();
-            },
-            complete: framework.unblockUI,
-        });
-        if (blocked) {
-            var message = _t('A popup window with your report was blocked. You ' +
-                             'may need to change your browser settings to allow ' +
-                             'popup windows for this page.');
-            this.do_warn(_t('Warning'), message, true);
-        }
-        return def.then(function () {
-            if (action.close_on_report_download) {
-                return self.doAction({type: "ir.actions.act_window_close"},
-                                     _.pick(options, "on_close"));
-            } else {
-                return options.on_close();
+    ActionManager.include({
+        /**
+         * Triggers the download of the report
+         * @param {Object} action - the description of the action to execute
+         * @param {Object} options - @see doAction for details
+         * @param {Deferred} resolved when the action has been executed
+         */
+        _triggerDownload: function (action, options, type) {
+            // Since _downloadReport doesn't have the report type, we must
+            // reimplement the method to be sure that is a controller report
+            // without breaking other modules
+            // If https://github.com/odoo/odoo/pull/28365 is merged and
+            // backported into 12.0, we don't need to reimplement nothing.
+            var self = this;
+            if (!CONTROLLER_KEYS.includes(type)) {
+                return self._super(action, options, type);
             }
-        });
-    },
+            var reportUrls = self._makeReportUrls(action);
+            framework.blockUI();
+            var def = $.Deferred();
+            var blocked = !session.get_file({
+                url: "/report/download",
+                data: {
+                    data: JSON.stringify([reportUrls[type], type]),
+                },
+                success: def.resolve.bind(def),
+                error: function () {
+                    crash_manager.rpc_error.apply(crash_manager, arguments);
+                    def.reject();
+                },
+                complete: framework.unblockUI,
+            });
+            if (blocked) {
+                var message = _t('A popup window with your report was ' +
+                                 'blocked. You may need to change your ' +
+                                 'browser settings to allow popup windows ' +
+                                 'for this page.');
+                this.do_warn(_t('Warning'), message, true);
+            }
+            return def.then(function () {
+                if (action.close_on_report_download) {
+                    return self.doAction({type: "ir.actions.act_window_close"},
+                                         _.pick(options, "on_close"));
+                }
+                return options.on_close();
+            });
+        },
 
-    _executeReportAction: function (action, options){
-        var self = this;
-        if (!CONTROLLER_KEYS.includes(action.report_type)) {
-            return self._super(action, options);
-        }
-        return self._triggerDownload(action, options, action.report_type);
-    },
+        /**
+         * Executes actions of type 'ir.actions.report'.
+         *
+         * @private
+         * @param {Object} action the description of the action to execute
+         * @param {Object} options @see doAction for details
+         * @returns {Deferred} resolved when the action has been executed
+         */
+        _executeReportAction: function (action, options) {
+            var self = this;
+            if (!CONTROLLER_KEYS.includes(action.report_type)) {
+                return self._super(action, options);
+            }
+            return self._triggerDownload(action, options, action.report_type);
+        },
 
-    _makeReportUrls: function (action) {
-        var self = this;
-        var res = self._super(action);
+        /**
+         * Extends upstream object to add controller URL (as key).
+         *
+         * @param {Object} action
+         * @returns {Object}
+         */
+        _makeReportUrls: function (action) {
+            var self = this;
+            var res = self._super(action);
 
-        var reportUrls = {}
+            var reportUrls = {};
 
-        $.each(CONTROLLER_KEYS, function(index, type) {
-            reportUrls[type] = "/report/controller/" + action.report_name;
-        });
+            $.each(CONTROLLER_KEYS, function (index, type) {
+                reportUrls[type] = "/report/controller/" + action.report_name;
+            });
 
-        // Reimplement upstream url generation
-        // check web/static/src/js/chrome/action_manager_report.js:180
-        if (_.isUndefined(action.data) || _.isNull(action.data) ||
-            (_.isObject(action.data) && _.isEmpty(action.data))) {
-            if (action.context.active_ids) {
-                var activeIDsPath = "/" + action.context.active_ids.join(',');
+            // Reimplement upstream url generation
+            // check web/static/src/js/chrome/action_manager_report.js:180
+            if (_.isUndefined(action.data) || _.isNull(action.data) ||
+                (_.isObject(action.data) && _.isEmpty(action.data))) {
+                if action.context.active_ids {
+                    var activeids = action.context.active_ids.join(',');
+                    var activeIDsPath = "/" + activeids;
+                    _.mapObject(reportUrls, function (value, type) {
+                        res[type] = value + activeIDsPath;
+                    });
+                }
+            } else {
+                // encoded data and context
+                var edata = encodeURIComponent(JSON.stringify(action.data));
+                var ecxt = encodeURIComponent(JSON.stringify(action.context));
+                var serializedOptionsPath = '?options=' + edata
+                serializedOptionsPath += '&context=' + ecxt
                 _.mapObject(reportUrls, function (value, type) {
-                    res[type] = value + activeIDsPath;
+                    res[type] = value + serializedOptionsPath;
                 });
             }
-        } else {
-            var serializedOptionsPath = '?options=' + encodeURIComponent(JSON.stringify(action.data));
-            serializedOptionsPath += '&context=' + encodeURIComponent(JSON.stringify(action.context));
-            _.mapObject(reportUrls, function (value, type) {
-                res[type] = value + serializedOptionsPath;
-            });
-        }
 
-        return res;
-    }
-});
+            return res;
+        },
+    });
 });

--- a/report_controller/static/src/js/qwebactionmanager.js
+++ b/report_controller/static/src/js/qwebactionmanager.js
@@ -93,8 +93,8 @@ odoo.define("report_controller.report", function (require) {
             // Reimplement upstream url generation
             // check web/static/src/js/chrome/action_manager_report.js:180
             if (_.isUndefined(action.data) || _.isNull(action.data) ||
-                (_.isObject(action.data) && _.isEmpty(action.data))) {
-                if action.context.active_ids {
+                _.isObject(action.data) && _.isEmpty(action.data)) {
+                if (action.context.active_ids) {
                     var activeids = action.context.active_ids.join(',');
                     var activeIDsPath = "/" + activeids;
                     _.mapObject(reportUrls, function (value, type) {

--- a/report_controller/views/assets.xml
+++ b/report_controller/views/assets.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <!--
+    Copyright 2018 Hugo Rodrigues
+    License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
+    -->
+    <template id="assets_backend" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/report_controller/static/src/js/qwebactionmanager.js"/>
+        </xpath>
+
+    </template>
+</odoo>

--- a/report_controller/views/ir_actions_report_view.xml
+++ b/report_controller/views/ir_actions_report_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="ir_actions_report_form" model="ir.ui.view">
+        <field name="name">ir.actions.report.form</field>
+        <field name="model">ir.actions.report</field>
+        <field name="inherit_id" ref="base.act_report_xml_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='report_name']" position="after">
+                <field name="controller_url"
+                    attrs="{'invisible': [('report_type', '!=', 'controller')],
+                            'required': [('report_type', '=', 'controller')]}" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/report_controller/views/ir_actions_report_view.xml
+++ b/report_controller/views/ir_actions_report_view.xml
@@ -5,10 +5,24 @@
         <field name="model">ir.actions.report</field>
         <field name="inherit_id" ref="base.act_report_xml_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='report_name']" position="after">
-                <field name="controller_url"
+            <xpath expr="//field[@name='report_type']" position="after">
+<!--                 <field name="controller_document_type" -->
+<!--                 	placeholder="pdf" -->
+<!--                     attrs="{'invisible': [('report_type', '!=', 'controller')], -->
+<!--                             'required': [('report_type', '=', 'controller')]}" /> -->
+                <field name="controller_content_type"
                     attrs="{'invisible': [('report_type', '!=', 'controller')],
                             'required': [('report_type', '=', 'controller')]}" />
+            </xpath>
+            <xpath expr="//field[@name='report_name']" position="after">
+                <label for="controller_url"
+                    attrs="{'invisible': [('report_type', '!=', 'controller')],
+                            'required': [('report_type', '=', 'controller')]}" />
+                <div name="controller_url"
+                    attrs="{'invisible': [('report_type', '!=', 'controller')]}" >
+	                <field name="controller_url" attrs="{'required': [('report_type', '=', 'controller')]}" />
+	                <p class="text-muted">Example: '/res.partner/%s' % object.ids</p>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Reimplemented the controller (pdf) report type, missing since Odoo 11.0
It duplicates some upstream code, since upstream has the base types hardcoded,
if the PR https://github.com/odoo/odoo/pull/28365 is merged and backported
into 12.0, we will need to refactor in order to remove the duplicated
code.