### PR TITLE
report_xlsx: fix report context propagation on records

### DIFF
--- a/report_xlsx/models/ir_report.py
+++ b/report_xlsx/models/ir_report.py
@@ -16,9 +16,9 @@ class ReportAction(models.Model):
         report_model = self.env.get(report_model_name)
         if report_model is None:
             raise UserError(_('%s model was not found' % report_model_name))
-        return report_model.with_context({
-            'active_model': self.model
-        }).create_xlsx_report(docids, data)
+        return report_model.with_context(
+            active_model=self.model,
+        ).create_xlsx_report(docids, data)
 
     @api.model
     def _get_report_from_name(self, report_name):

--- a/report_xlsx/report/report_xlsx.py
+++ b/report_xlsx/report/report_xlsx.py
@@ -37,7 +37,9 @@ class ReportXlsxAbstract(models.AbstractModel):
             ids = data["context"].get('active_ids', [])
         else:
             ids = self.env.context.get('active_ids', [])
-        return self.env[self.env.context.get('active_model')].browse(ids)
+        # propagate context anyway
+        # let it fail explicitely if `active_model` is not there
+        return self.env[self.env.context['active_model']].browse(ids)
 
     def create_xlsx_report(self, docids, data):
         objs = self._get_objs_for_report(docids, data)


### PR DESCRIPTION
Without this change If you return a custom action that sets a custom context -> you lose it -> if your report depends on it... it's broken :sob: 

@adrienpeiffer @sbidoul this fixes XLS export on `mis.report.instance` :wink: 

Fixes #326