### PR TITLE
[IMP] do not set views ids on sql automatic win action

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -437,20 +437,11 @@ class BiSQLView(models.Model):
     def _prepare_action(self):
         self.ensure_one()
         view_mode = self.view_order
-        first_view = view_mode.split(',')[0]
-        if first_view == 'tree':
-            view_id = self.tree_view_id.id
-        elif first_view == 'pivot':
-            view_id = self.pivot_view_id.id
-        else:
-            view_id = self.graph_view_id.id
         return {
             'name': self._prepare_action_name(),
             'res_model': self.model_id.model,
             'type': 'ir.actions.act_window',
             'view_mode': view_mode,
-            'view_id': view_id,
-            'search_view_id': self.search_view_id.id,
         }
 
     @api.multi


### PR DESCRIPTION
## Actual situation

- You create an sql query with "bi_sql_editor"
- you want to modify default views, available options are:

1. Modify created view, if you need to reset the sql query then you loose the changes
2. Modify views by extending. Then you can not reset sql quer because of constraint on ir.ui.view with parent view
3. You can create new views with priority lower than 16. Great option! but....

## Problem found
The window action created by bi_sql_editor explicitly refers to view_id and view_search_id while those two fields are optional and really no needed. Better to let odoo choose the right view by priority
