### PR TITLE
[FIX] UI Not being blocked when exporting xlsx

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -38,7 +38,14 @@ class ReportController(report.ReportController):
                     content_disposition(report.report_file + '.xlsx')
                 )
             ]
-            return request.make_response(xlsx, headers=xlsxhttpheaders)
+            token = data.get('token')
+            cookies = None
+            if token:
+                cookies = {
+                    'fileToken': token,
+                }
+            return request.make_response(xlsx, headers=xlsxhttpheaders,
+                                         cookies=cookies)
         return super(ReportController, self).report_routes(
             reportname, docids, converter, **data
         )

--- a/report_xlsx/static/src/js/report/qwebactionmanager.js
+++ b/report_xlsx/static/src/js/report/qwebactionmanager.js
@@ -36,9 +36,9 @@ ActionManager.include({
                     if(cloned_action && options && !cloned_action.dialog){
                         options.on_close();
                     }
-                }
+                },
+                complete: framework.unblockUI,
             });
-            framework.unblockUI();
             return;
         }
         return self._super(action, options);


### PR DESCRIPTION
* `framework.unblockUI` should be called after `get_file` has finished
(now its unblocking the UI just after it is blocked)
* The Response from the server should set a *fileToken* cookie as
requested in the docstring of `get_file` in order to trigger the
callbacks

`get_file` func can be found in /web/static/src/js/core/ajax.js :: 262