### PR TITLE
report_xml: add custom filename to response headers

### DIFF
--- a/report_xml/__manifest__.py
+++ b/report_xml/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "XML Reports",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "category": "Reporting",
     "website": "https://github.com/OCA/reporting-engine",
     "author": "Grupo ESOC Ingeniería de Servicios, "

--- a/report_xml/controllers/main.py
+++ b/report_xml/controllers/main.py
@@ -2,8 +2,11 @@
 # Copyright (C) 2014-2015  Grupo ESOC <www.grupoesoc.es>
 # License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl.html).
 
+import time
+
 from odoo.addons.web.controllers import main as report
-from odoo.http import content_disposition, route
+from odoo.http import content_disposition, request, route
+from odoo.tools.safe_eval import safe_eval
 
 
 class ReportController(report.ReportController):
@@ -21,7 +24,17 @@ class ReportController(report.ReportController):
             response.data = response.data.strip()
             response.headers.set("Content-Type", "text/xml")
             response.headers.set('Content-length', len(response.data))
+            # set filename
+            action_report_obj = request.env['ir.actions.report']
+            report = action_report_obj._get_report_from_name(reportname)
+            filename = report.name
+            if docids:
+                ids = [int(x) for x in docids.split(",")]
+                records = request.env[report.model].browse(ids)
+                if report.print_report_name and not len(records) > 1:
+                    filename = safe_eval(report.print_report_name,
+                                         {'object': records, 'time': time})
             response.headers.set(
                 'Content-Disposition',
-                content_disposition(reportname + ".xml"))
+                content_disposition(filename + ".xml"))
         return response


### PR DESCRIPTION

The purpose of this PR is that when the user downloads the file from an xml report (by clicking on: **Print -> [report_name]** in the sidebar), it has the name defined in the print_report_name attribute of the xml report

Cc @Tecnativa