### PR TITLE
[11.0] [FIX] report_xlsx: context is overwritten when creating report recordset

### DIFF
--- a/report_xlsx/models/ir_report.py
+++ b/report_xlsx/models/ir_report.py
@@ -16,9 +16,9 @@ class ReportAction(models.Model):
         report_model = self.env.get(report_model_name)
         if report_model is None:
             raise UserError(_('%s model was not found' % report_model_name))
-        return report_model.with_context({
-            'active_model': self.model
-        }).create_xlsx_report(docids, data)
+        return report_model.with_context(active_model=self.model).create_xlsx_report(
+            docids, data
+        )
 
     @api.model
     def _get_report_from_name(self, report_name):


### PR DESCRIPTION
This error implies losing user language in report context, so traslatable fields are shown in base language instead of user one.

The bug was already fixed in v12 during addon migration, I simply made the same changes on `with_context()` call during XLSX report rendering.