### PR TITLE
[10.0][FIX]date fields as date

### DIFF
--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -45,7 +45,7 @@ class BiSQLViewField(models.Model):
         'numeric': 'float',
         'text': 'char',
         'character varying': 'char',
-        'date': 'datetime',
+        'date': 'date',
         'timestamp without time zone': 'datetime',
     }
 


### PR DESCRIPTION
I am having issues when querying date fields. They are converted to datetime in the views (even if I select date as field type). Consequently the timezone is applied. Consequently dates are shown in different dates.

For example: invoice date 01-01-2019 -> to datetime: 01-01-2019 00:00:00 UTC -> If I run the report in a place with timezone UTC-X I get invoice date 31-12-2018 --> Not correct.

The solution here seems not to affect datetime fileds as they are queried as timestamp without time zone. However I am not sure this works for every use case, so I'd appreciate a lot opinions of people that use this module frequently. 

Thank you!