### PR TITLE
[FIX] travis without xvfb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,7 @@ addons:
       - python-lxml # because pip installation is slow
       - pdftk
       - wkhtmltopdf  # only add if needed and check the before_install section below
-  postgresql: "9.6"
-
-# set up an X server to run wkhtmltopdf.
-before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  postgresql: "9.6" 
 
 language: python
 


### PR DESCRIPTION
There is some issues with xvfb and travis is failing on 11.0:

https://travis-ci.org/OCA/reporting-engine/builds/566830567
https://travis-ci.org/OCA/reporting-engine/builds/564794138

Travis now should work without issues and tests should be executed properly.

@pedrobaeza @jarroyomorales 