### PR TITLE
[12.0][IMP]date to datetime conversion when autotyping

### DIFF
--- a/report_xlsx_helper/report/report_xlsx_abstract.py
+++ b/report_xlsx_helper/report/report_xlsx_abstract.py
@@ -1,7 +1,7 @@
 # Copyright 2009-2018 Noviat.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from datetime import datetime
+from datetime import datetime, date
 import re
 from types import CodeType
 from xlsxwriter.utility import xl_rowcol_to_cell
@@ -502,6 +502,10 @@ class ReportXlsxAbstract(models.AbstractModel):
                     elif isinstance(cell_value, (int, float)):
                         cell_type = 'number'
                     elif isinstance(cell_value, datetime):
+                        cell_type = 'datetime'
+                    elif isinstance(cell_value, date):
+                        cell_value = datetime.combine(
+                            cell_value, datetime.min.time()) 
                         cell_type = 'datetime'
                     else:
                         if not cell_value:

--- a/report_xlsx_helper/report/report_xlsx_abstract.py
+++ b/report_xlsx_helper/report/report_xlsx_abstract.py
@@ -505,7 +505,7 @@ class ReportXlsxAbstract(models.AbstractModel):
                         cell_type = 'datetime'
                     elif isinstance(cell_value, date):
                         cell_value = datetime.combine(
-                            cell_value, datetime.min.time()) 
+                            cell_value, datetime.min.time())
                         cell_type = 'datetime'
                     else:
                         if not cell_value:

--- a/report_xlsx_helper/report/test_partner_report_xlsx.py
+++ b/report_xlsx_helper/report/test_partner_report_xlsx.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2009-2018 Noviat.
+# Copyright 2009-2019 Noviat.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models
@@ -52,6 +51,15 @@ class TestPartnerXlsx(models.AbstractModel):
                     'value': self._render("customer_formula"),
                 },
                 'width': 14,
+            },
+            'date': {
+                'header': {
+                    'value': 'Date',
+                },
+                'data': {
+                    'value': self._render("partner.date"),
+                },
+                'width': 13,
             },
         }
 

--- a/report_xlsx_helper/tests/test_report_xlsx_helper.py
+++ b/report_xlsx_helper/tests/test_report_xlsx_helper.py
@@ -1,5 +1,7 @@
-# Copyright 2009-2018 Noviat.
+# Copyright 2009-2019 Noviat.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date
 
 from odoo.tests.common import TransactionCase
 
@@ -8,8 +10,11 @@ class TestReportXlsxHelper(TransactionCase):
 
     def setUp(self):
         super(TestReportXlsxHelper, self).setUp()
+        today = date.today()
         p1 = self.env.ref('base.res_partner_1')
         p2 = self.env.ref('base.res_partner_2')
+        p1.date = today
+        p2.date = today
         self.partners = p1 + p2
         ctx = {
             'report_name': 'report_xlsx_helper.test_partner_xlsx',

--- a/report_xlsx_helper_demo/report/partner_export_xlsx.py
+++ b/report_xlsx_helper_demo/report/partner_export_xlsx.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2009-2018 Noviat.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 


### PR DESCRIPTION
This PR simplifies the syntax in the templates when using ORM date fields:

E;g. self._render("aml.date") will now be converted automatically to datetime before passing the value to xlsxwriter.