### PR TITLE
[12.0][IMP] report_xlsx, make sure print_report_name works

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -3,8 +3,10 @@
 
 from odoo.addons.web.controllers import main as report
 from odoo.http import content_disposition, route, request
+from odoo.tools.safe_eval import safe_eval
 
 import json
+import time
 
 
 class ReportController(report.ReportController):
@@ -29,13 +31,18 @@ class ReportController(report.ReportController):
             xlsx = report.with_context(context).render_xlsx(
                 docids, data=data
             )[0]
+            report_name = report.report_file
+            if report.print_report_name and not len(docids) > 1:
+                obj = request.env[report.model].browse(docids[0])
+                report_name = safe_eval(report.print_report_name,
+                                        {'object': obj, 'time': time})
             xlsxhttpheaders = [
                 ('Content-Type', 'application/vnd.openxmlformats-'
                                  'officedocument.spreadsheetml.sheet'),
                 ('Content-Length', len(xlsx)),
                 (
                     'Content-Disposition',
-                    content_disposition(report.report_file + '.xlsx')
+                    content_disposition(report_name + '.xlsx')
                 )
             ]
             return request.make_response(xlsx, headers=xlsxhttpheaders)


### PR DESCRIPTION
This improve make sure `print_report_name` field in report action will works, as it not work previously.

Note: do I need to set minor version to 12.0.1.0.1 ? Is it updated auto by Bot?