### PR TITLE
[FIX] report_custom_filename: Use model specified on the report to br…

### DIFF
--- a/report_custom_filename/controllers/reports.py
+++ b/report_custom_filename/controllers/reports.py
@@ -24,7 +24,7 @@ class Reports(main.Reports):
             ('report_name', '=', action['report_name']),
             ('download_filename', '!=', False)])
         for report in reports:
-            objects = http.request.session.model(context['active_model'])\
+            objects = http.request.session.model(report.model)\
                 .browse(context['active_ids'])
             generated_filename = mail_template.mako_template_env\
                 .from_string(report.download_filename)\


### PR DESCRIPTION
…owse the active records

The active_model into the context is not always the model for which the report is generated. For exemple if you open an invoice from the smart button on a sale order, the active model is 'sale.order' and not 'account.invoice'.