### PR TITLE
[11.0][FIX] Report xlsx res_partner

### DIFF
--- a/report_xlsx/report/report_partner_xlsx.py
+++ b/report_xlsx/report/report_partner_xlsx.py
@@ -9,7 +9,7 @@ class PartnerXlsx(models.AbstractModel):
     _inherit = 'report.report_xlsx.abstract'
 
     def generate_xlsx_report(self, workbook, data, partners):
-        for obj in partners:
-            sheet = workbook.add_worksheet('Report')
+        sheet = workbook.add_worksheet('Report')
+        for i, obj in enumerate(partners):
             bold = workbook.add_format({'bold': True})
-            sheet.write(0, 0, obj.name, bold)
+            sheet.write(i, 0, obj.name, bold)


### PR DESCRIPTION
When trying to print the xlsx report of more than one `res.partner` I was getting the following error.
`Exception: Sheetname 'Report', with case ignored, is already in use.`

This PR intends to fix it.