### PR TITLE
[12.0][ENH] report_xlsx_helper : dynamic function _write_line

### DIFF
--- a/report_xlsx_helper/readme/CONTRIBUTORS.rst
+++ b/report_xlsx_helper/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Luc De Meyer <luc.demeyer@noviat.com>
+* Saran Lim. <saranl@ecosoft.co.th>

--- a/report_xlsx_helper/report/report_xlsx_abstract.py
+++ b/report_xlsx_helper/report/report_xlsx_abstract.py
@@ -464,15 +464,16 @@ class ReportXlsxAbstract(models.AbstractModel):
         return row_pos + 2
 
     def _write_line(self, ws, row_pos, ws_params, col_specs_section=None,
-                    render_space=None, default_format=None):
+                    render_space=None, default_format=None,
+                    col_specs='col_specs', wanted_list='wanted_list'):
         """
         Write a line with all columns included in the 'wanted_list'.
         Use the entry defined by the col_specs_section.
         An empty cell will be written if no col_specs_section entry
         for a column.
         """
-        col_specs = ws_params.get('col_specs')
-        wl = ws_params.get('wanted_list') or []
+        col_specs = ws_params.get(col_specs)
+        wl = ws_params.get(wanted_list) or []
         pos = 0
         for col in wl:
             if col not in col_specs:


### PR DESCRIPTION
This module should be help write data from criteria wizard or else.
If you want to write criteria wizard in xlsx.
you can add attribute `col_specs` and `wanted_list`
in function `_write_line`

```
# Filters Criteria
row_pos = self._write_line(
            ws, row_pos, ws_params, col_specs_section='header',
            default_format=self.format_theader_yellow_left,
            col_specs='col_filters', wanted_list='data_filters')
row_pos = self._write_line(
            ws, row_pos, ws_params, col_specs_section='data',
            col_specs='col_filters', wanted_list='data_filters')
```

**Example**
I would like to get criteria `Bank Account` and `Date` in xlsx
![Selection_003](https://user-images.githubusercontent.com/20896369/72864413-81807900-3d06-11ea-92f1-81658dad7835.png)

![Selection_004](https://user-images.githubusercontent.com/20896369/72864569-12efeb00-3d07-11ea-930c-a45f4a3a1954.png)
