### PR TITLE
[12.0][ENH] report_xlsx_helper : dynamic position in excel

### DIFF
--- a/report_xlsx_helper/report/report_xlsx_abstract.py
+++ b/report_xlsx_helper/report/report_xlsx_abstract.py
@@ -489,6 +489,15 @@ class ReportXlsxAbstract(models.AbstractModel):
                 cell_format = default_format
             else:
                 cell_value = cell_spec.get('value')
+                cell_column = cell_spec.get('col') or False
+                if cell_column and isinstance(cell_column, str):
+                    # Convert base26 column string to number.
+                    expn = 0
+                    col_num = 0
+                    for char in reversed(cell_column.upper()):
+                        col_num += (ord(char) - ord('A') + 1) * (26 ** expn)
+                        expn += 1
+                    pos = col_num - 1
                 if isinstance(cell_value, CodeType):
                     cell_value = self._eval(cell_value, render_space)
                 cell_type = cell_spec.get('type')


### PR DESCRIPTION
Normally, position will start at 0 (column A) but sometime we need to start at other column in excel.
you can add attribute 'col' in dict for fix position.

Example : 
```
filters_dict = {
            '01_period': {
                'header': {
                    'value': 'Period',
                    'col': 'D',              <<<<<<<<<<<<<<   Add col
                },
                'data': {
                    'value': self._render('period'),
                    'col': 'D',              <<<<<<<<<<<<<<   Add col
                },
                'width': 12,
            },
        }
```
In period filter will start at column D
![Selection_003](https://user-images.githubusercontent.com/20896369/76590264-13df1500-651f-11ea-918a-7c55fcf3c4c8.png)

