### PR TITLE
[IMP][12.0] bi_sql_editor : add action context

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -120,6 +120,15 @@ class BiSQLView(models.Model):
             'sql_valid': [('readonly', False)],
         })
 
+    action_context = fields.Text(
+        string="Action Context", default="{}", readonly=True,
+        help="Define here a context that will be used"
+        " by default, when creating the action.",
+        states={
+            'draft': [('readonly', False)],
+            'sql_valid': [('readonly', False)],
+        })
+
     has_group_changed = fields.Boolean(copy=False)
 
     bi_sql_view_field_ids = fields.One2many(
@@ -451,6 +460,7 @@ class BiSQLView(models.Model):
             'view_mode': view_mode,
             'view_id': view_id,
             'search_view_id': self.search_view_id.id,
+            'context': self.action_context,
         }
 
     @api.multi

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -106,6 +106,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 <field name="has_group_changed" invisible="1"/>
                             </group>
                         </page>
+                        <page string="Action Settings">
+                            <group string="Context">
+                                <field name="action_context" nolabel="1" colspan="4"/>
+                            </group>
+                        </page>
                         <page string="Extras Information">
                             <group>
                                 <group string="Model">


### PR DESCRIPTION
Trivial PR to add a field ``action_context`` on the ``bi.sql.view`` model, that will be used, when creating the action as a context

This context can be useful to enable some extra features.

Specially with the module ``web_pivot_computed_measure`` (https://github.com/OCA/web/pull/1547)
(same spirit than in  ``bi_sql_editor_aggregate`` (https://github.com/OCA/reporting-engine/pull/352) but with two fields)

CC : @richard-willdooit, @CasVissers

#GRAPOCA