### PR TITLE
[12.0][FIX] bi_view_editor: window functions without ORDER BY clause do not have reliable behavior

### DIFF
--- a/bi_view_editor/models/bve_view.py
+++ b/bi_view_editor/models/bve_view.py
@@ -295,8 +295,16 @@ class BveView(models.Model):
         self._cr.execute('DROP TABLE IF EXISTS %s', (AsIs(view_name), ))
 
         # create postgres view
-        self.env.cr.execute('CREATE or REPLACE VIEW %s as (%s)', (
-            AsIs(view_name), AsIs(query), ))
+        try:
+            with self.env.cr.savepoint():
+                self.env.cr.execute('CREATE or REPLACE VIEW %s as (%s)', (
+                    AsIs(view_name), AsIs(query), ))
+        except Exception as e:
+            raise UserError(
+                _("Error creating the view '{query}':\n{error}")
+                .format(
+                    query=query,
+                    error=e))
 
     @api.depends('line_ids', 'state', 'over_condition')
     def _compute_sql_query(self):

--- a/bi_view_editor/readme/ROADMAP.rst
+++ b/bi_view_editor/readme/ROADMAP.rst
@@ -5,4 +5,3 @@
 * Data the user has no access to (e.g. in a multi company situation) can be
   viewed by making a view. Would be nice if models available to select when
   creating a view are limited to the ones that have intersecting groups.
-* Raise a warning in case the SQL query is not correct.

--- a/bi_view_editor/readme/ROADMAP.rst
+++ b/bi_view_editor/readme/ROADMAP.rst
@@ -5,3 +5,4 @@
 * Data the user has no access to (e.g. in a multi company situation) can be
   viewed by making a view. Would be nice if models available to select when
   creating a view are limited to the ones that have intersecting groups.
+* Raise a warning in case the SQL query is not correct.

--- a/bi_view_editor/readme/USAGE.rst
+++ b/bi_view_editor/readme/USAGE.rst
@@ -21,3 +21,6 @@ To access the created BI View with a dedicated menu:
 A more advanced UI is also available under the "Details" tab. It provides extra
 possibilities for more advanced users, like to use LEFT JOIN instead of the
 default INNER JOIN.
+
+It also possible to improve the IDs generation for new views by adding an `Over Condition` in the "SQL" tab, see https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS for further details.
+For instance, an ORDER BY clause helps preventing unreliable behavior when filtering the generated views.

--- a/bi_view_editor/views/bve_view.xml
+++ b/bi_view_editor/views/bve_view.xml
@@ -85,8 +85,9 @@
                             </group>
                         </page>
                         <page string="SQL" groups="base.group_no_one">
+                            <field name="query"/>
                             <group>
-                                <field name="query" nolabel="1" />
+                                <field name="over_condition"/>
                             </group>
                         </page>
                         <page string="Security">


### PR DESCRIPTION
Fix #388.
An order by clause is highly recommended when using window functions:
> Without ORDER BY, rows are processed in an unspecified order.

(from https://www.postgresql.org/docs/10/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS)

This modification allows a (technical) user to specify such condition and others, like PARTITION BY.