### PR TITLE
[FIX] report_qweb_signer: reprint report crash

### DIFF
--- a/report_qweb_signer/models/ir_actions_report.py
+++ b/report_qweb_signer/models/ir_actions_report.py
@@ -143,7 +143,7 @@ class IrActionsReport(models.Model):
                     "The signed PDF document '%s/%s' was loaded from the "
                     "database", self.report_name, res_ids,
                 )
-                return signed_content
+                return signed_content, 'pdf'
         content, ext = super(IrActionsReport, self).render_qweb_pdf(res_ids,
                                                                     data)
         if certificate:


### PR DESCRIPTION
`render_qweb_pdf` must return a tuple of `(content, 'pdf')`

@Tecnativa TT24322