### PR TITLE
[FIX] bi_sql_editor: allow XML-RPC calls

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -264,6 +264,7 @@ class BiSQLView(models.Model):
                 sql_view.cron_id = self.env['ir.cron'].create(
                     sql_view._prepare_cron()).id
             sql_view.state = 'model_valid'
+        return True
 
     @api.multi
     def button_set_draft(self):
@@ -302,6 +303,7 @@ class BiSQLView(models.Model):
         self.menu_id = self.env['ir.ui.menu'].create(
             self._prepare_menu()).id
         self.write({'state': 'ui_valid'})
+        return True
 
     @api.multi
     def button_update_model_access(self):


### PR DESCRIPTION
Hi. trivial patch. add ``return True`` on two functions, to allow XML-RPC calls. 

Other exemple in Odoo Core : 
https://github.com/odoo/odoo/commit/dc043cf1bb4602fb298fca8b8d17765e3a6b93ff

Other similar PR : https://github.com/OCA/server-tools/pull/1854