### PR TITLE
[11.0][FIX] Fix error when downloading xlsx reports

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -45,7 +45,7 @@ class ReportController(report.ReportController):
                     content_disposition(report_name + '.xlsx')
                 )
             ]
-            return request.make_response(xlsx, headers=xlsxhttpheaders)
+            return request.make_response(xlsx, headers=xlsxhttpheaders, cookies={'fileToken': request.params.get('token')})
         return super(ReportController, self).report_routes(
             reportname, docids, converter, **data
         )

--- a/report_xlsx/static/src/js/report/qwebactionmanager.js
+++ b/report_xlsx/static/src/js/report/qwebactionmanager.js
@@ -31,6 +31,7 @@ ActionManager.include({
                     report_xlsx_url,
                     cloned_action.report_type
                 ])},
+                complete: framework.unblockUI,
                 error: crash_manager.rpc_error.bind(crash_manager),
                 success: function (){
                     if(cloned_action && options && !cloned_action.dialog){
@@ -38,7 +39,6 @@ ActionManager.include({
                     }
                 }
             });
-            framework.unblockUI();
             return;
         }
         return self._super(action, options);


### PR DESCRIPTION
The frontend was expecting a cookie with value 'fileToken' to be able to complete the ajax call, this lead to error in frontend since the ajax call was never completed.

Probably due to this error is that the method framework.unblockUI() was put outside of the ajax call at qwebactionmanager.js, so this made that the UI was unblocked immediately after clicking on download report and not when report was actually downloaded, so we wouldn't see the loading spinner while the report was being generated. This was fixed too.