### PR TITLE
[FIX] delete sql view by order desc, to avoid errors if one sql view depends on another sql view

### DIFF
--- a/bi_sql_editor/hooks.py
+++ b/bi_sql_editor/hooks.py
@@ -6,6 +6,6 @@ from odoo.api import Environment
 
 def uninstall_hook(cr, registry):
     env = Environment(cr, SUPERUSER_ID, {})
-    recs = env['bi.sql.view'].search([])
+    recs = env['bi.sql.view'].search([], order="id desc")
     for rec in recs:
         rec.button_set_draft()


### PR DESCRIPTION
Hi all,

proposing a trivial patch. when uninstalling bi_sql_editor, the hook will try to set to draft each sql view. If a view depends on another view, it will fail. 
Changing the order will solve the problem.