### PR TITLE
[FIX] report_qr: New QR Library does not contain the old failure

### DIFF
--- a/report_qr/models/ir_actions_report.py
+++ b/report_qr/models/ir_actions_report.py
@@ -17,9 +17,8 @@ class IrActionsReport(models.Model):
             "svg-fragment": svg.SvgFragmentImage,
             "svg-path": svg.SvgPathImage,
         }
-        # Color parameters seem to be inverted in the library
-        back_color = kwargs.pop("back_color", "black")
-        fill_color = kwargs.pop("fill_color", "white")
+        back_color = kwargs.pop("back_color", "white")
+        fill_color = kwargs.pop("fill_color", "black")
         try:
             # Defaults to png if the argument is unknown
             image_factory = factories.get(factory, pil.PilImage)


### PR DESCRIPTION
With Odoo 13, this is no longer necessary, as the version of QR was changed:
https://github.com/odoo/odoo/blob/13.0/requirements.txt#L38
https://github.com/odoo/odoo/blob/12.0/requirements.txt#L37

This has made the old issue about background fixed.

With the current code and the default version of QR we have:

![imagen](https://user-images.githubusercontent.com/28590170/95560421-8ebad080-0a19-11eb-80eb-ef50ee966d4a.png)
 
and we should obtain:

![imagen](https://user-images.githubusercontent.com/28590170/95561660-574d2380-0a1b-11eb-87e6-35b749cc8386.png)
