### PR TITLE
[12.0][IMP][report_qr] Allow setting proposed filename

### DIFF
--- a/report_qr/controllers/qr.py
+++ b/report_qr/controllers/qr.py
@@ -5,8 +5,11 @@ from odoo.http import request
 
 class Home(http.Controller):
 
-    @http.route('/report/qr', type='http', auth="public")
-    def report_qr(self, value, box_size=3, border=3, factory='png', **kwargs):
+    @http.route(['/report/qr',
+                 '/report/qr/<qr_image_name>',
+                 ], type='http', auth="public")
+    def report_qr(self, value, box_size=3, border=3, factory='png',
+                  qr_image_name='qr_image_name', **kwargs):
         try:
             barcode = request.env['ir.actions.report'].qr_generate(
                 value, box_size=box_size, border=border,

--- a/report_qr/readme/USAGE.rst
+++ b/report_qr/readme/USAGE.rst
@@ -2,6 +2,10 @@ When creating new reports, you should use a path like the following::
 
     <img t-att-src="'/report/qr/?value=%s&amp;error_correction=%s' % ('HELLO WORLD!', 3)" style="width:100;height:100"/>
 
+OR::
+
+    <img t-att-src="'/report/qr/image_name.ext?value=%s&amp;error_correction=%s' % ('HELLO WORLD!', 3)" style="width:100;height:100"/>
+
 
 The **error_correction** parameter controls the error correction used for the QR Code. The following four constants are made available:
 
@@ -16,3 +20,5 @@ The **border** parameter controls how many boxes thick the border should be (the
 The **version** parameter is an integer from 1 to 40 that controls the size of the QR Code (the smallest, version 1, is a 21x21 matrix). Set to None and use the fit parameter when making the code to determine this automatically.
 
 **fill_color** and **back_color** can change the background and the painting color of the QR, when using the default image factory.
+
+Adding a trailing filename at the url will allow downloading the qr image with that name proposed.


### PR DESCRIPTION
Setting arbitrary filename trailing the URL to allow downloading
the QR image with the proposed name.