### PR TITLE
 [FIX] bi_sql_editor : handle correctly translation for action name

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -651,7 +651,9 @@ class BiSQLView(models.Model):
             if sql_view.action_id:
                 # Alter name of the action, to display last refresh
                 # datetime of the materialized view
-                sql_view.action_id.name = sql_view._prepare_action_name()
+                sql_view.action_id.with_context(
+                    lang=self.env.user.lang
+                ).name = sql_view._prepare_action_name()
 
     @api.multi
     def _refresh_size(self):


### PR DESCRIPTION
Trivial patch.

without this patch, when the cron is executing the refresh of the materialized view, the name of the action is not correctly updated.