### PR TITLE
[FIX] Import time from safe_eval

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -31,7 +31,7 @@ class ReportController(report.ReportController):
             report_name = report.report_file
             if report.print_report_name and not len(docids) > 1:
                 obj = request.env[report.model].browse(docids[0])
-                report_name = safe_eval(report.print_report_name, {"object": obj})
+                report_name = safe_eval(report.print_report_name, {"object": obj, "time": time})
             xlsxhttpheaders = [
                 (
                     "Content-Type",

--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -4,7 +4,7 @@
 import json
 
 from odoo.http import content_disposition, request, route
-from odoo.tools.safe_eval import safe_eval
+from odoo.tools.safe_eval import safe_eval, time
 
 from odoo.addons.web.controllers import main as report
 


### PR DESCRIPTION
In v14, Odoo now requires that modules be wrapped by safe_eval.
Attempting to evaluate a string with modules that are not imported from safe_eval will throw an error.

See below references.

https://github.com/odoo/odoo/blob/61e5389236ad767827ef2fe039aa78b20848298e/addons/web/controllers/main.py#L41
https://github.com/odoo/odoo/blob/61e5389236ad767827ef2fe039aa78b20848298e/odoo/tools/safe_eval.py#L416