### PR TITLE
Add "only-inner" class in report_qweb_element_page_visibility module

### DIFF
--- a/report_qweb_element_page_visibility/readme/CONTRIBUTORS.rst
+++ b/report_qweb_element_page_visibility/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Alessio Gerace <alessio.gerace@agilebg.com>
 * Alex Comba <alex.comba@agilebg.com>
 * Saran Limpajitkutaporn <saranl@ecosoft.co.th>
+* Pelayo García <pelayo.garcia@btp.es>

--- a/report_qweb_element_page_visibility/readme/CONTRIBUTORS.rst
+++ b/report_qweb_element_page_visibility/readme/CONTRIBUTORS.rst
@@ -3,4 +3,3 @@
 * Alessio Gerace <alessio.gerace@agilebg.com>
 * Alex Comba <alex.comba@agilebg.com>
 * Saran Limpajitkutaporn <saranl@ecosoft.co.th>
-* Pelayo García <pelayo.garcia@btp.es>

--- a/report_qweb_element_page_visibility/readme/DESCRIPTION.rst
+++ b/report_qweb_element_page_visibility/readme/DESCRIPTION.rst
@@ -2,5 +2,6 @@ This module allows you to use 4 classes in QWEB reports:
 
 * not-first-page: shows element in every page but first
 * not-last-page: shows element in every page but last
+* only-inner: shows element in every page but first and last
 * first-page: shows element only on first page
 * last-page: shows element only on last page

--- a/report_qweb_element_page_visibility/views/layouts.xml
+++ b/report_qweb_element_page_visibility/views/layouts.xml
@@ -44,6 +44,9 @@
                             'last-page': function (elt) {
                                 elt.style.visibility = (vars.sitepage === vars.sitepages) ? "visible" : "hidden";
                             },
+                            'only-inner': function (elt) {
+                                elt.style.visibility = (vars.sitepage === vars.sitepages) || (vars.sitepage === vars.frompage) ? "hidden" : "visible";
+                            },
                         };
                         for (var klass in operations) {
                             var y = document.getElementsByClassName(klass);


### PR DESCRIPTION
Add the ability to hide an item on both the first and last pages of a report to the `report_qweb_element_page_visibility` module