### PR TITLE
[13.0][FIX] _py3o_parser_context._old_format_lang

### DIFF
--- a/report_py3o/models/_py3o_parser_context.py
+++ b/report_py3o/models/_py3o_parser_context.py
@@ -130,4 +130,4 @@ class Py3oParserContext(object):
                 no_break_space=True,
             )
 
-        return self._format_date(self._env, value)
+        return self._format_date(value)


### PR DESCRIPTION
A useless env parameter in calling _format_date causes the value to be lost before getting formatted.
