### PR TITLE
[13.0][FIX]report_xlsx multi-company bug

### DIFF
--- a/report_xlsx/static/src/js/report/action_manager_report.js
+++ b/report_xlsx/static/src/js/report/action_manager_report.js
@@ -39,6 +39,7 @@ odoo.define("report_xlsx.report", function(require) {
                     url: new_url,
                     data: {
                         data: JSON.stringify([new_url, type]),
+                        context: JSON.stringify(cloned_action.context),
                     },
                     success: resolve,
                     error: error => {


### PR DESCRIPTION
This PR fixes https://github.com/OCA/reporting-engine/issues/470
Context dropping (hence also allowed_company_ids) causing access errors in multi-company environment.

We'll also need to forward port this fix to 14.0.
