### PR TITLE
[14.0][FIX] report_xlsx_helper: force Libreoffice to recompute formulas

### DIFF
--- a/report_xlsx_helper/report/report_xlsx_abstract.py
+++ b/report_xlsx_helper/report/report_xlsx_abstract.py
@@ -723,6 +723,7 @@ class ReportXlsxAbstract(models.AbstractModel):
                 if isinstance(cell_format, CodeType):
                     cell_format = self._eval(cell_format, render_space)
                 args_data.append(cell_format)
+            self._apply_formula_quirk(args_data, cell_type, cell_format)
             if colspan > 1:
                 args_pos += [row_pos, pos + colspan - 1]
                 args = args_pos + args_data
@@ -734,6 +735,15 @@ class ReportXlsxAbstract(models.AbstractModel):
             pos += colspan
 
         return row_pos + 1
+
+    @staticmethod
+    def _apply_formula_quirk(args_data, cell_type, cell_format):
+        """ Insert empty value to force LibreOffice to recompute the value """
+        if cell_type == "formula":
+            if not cell_format:
+                # Insert positional argument for missing format
+                args_data.append(None)
+            args_data.append("")
 
     @staticmethod
     def _render(code):


### PR DESCRIPTION
As per https://xlsxwriter.readthedocs.io/faq.html:

Q. Why do my formulas show a zero result in some, non-Excel applications?
A. [...] Or, you can set a blank result in the formula, which will also force
recalculation.

Before the fix:
![image](https://user-images.githubusercontent.com/1033124/107367909-2ae80780-6ae0-11eb-931c-12badf36d4a2.png)

After the fix:
![image](https://user-images.githubusercontent.com/1033124/107367941-34716f80-6ae0-11eb-86b9-52aea400b1f7.png)

I could not add the lines inline because of 
`report_xlsx_helper/report/report_xlsx_abstract.py:564:5: C901 'ReportXlsxAbstract._write_line' is too complex (18)`
