### PR TITLE
[FIX] report_py3o: wrong extension for .odt files in zip

### DIFF
--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -203,8 +203,10 @@ class Py3oReport(models.TransientModel):
         """ This function to generate our py3o report
         """
         self.ensure_one()
+        action_report = self.ir_actions_report_id
+        filetype = action_report.py3o_filetype
         result_fd, result_path = tempfile.mkstemp(
-            suffix=".ods", prefix="p3o.report.tmp."
+            suffix="." + filetype, prefix="p3o.report.tmp."
         )
         tmpl_data = self.get_template(model_instance)
 

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -205,6 +205,8 @@ class Py3oReport(models.TransientModel):
         self.ensure_one()
         action_report = self.ir_actions_report_id
         filetype = action_report.py3o_filetype
+        if filetype not in ("odt", "ods", "odp", "fodt", "fods", "fodp"):
+            filetype = "ods"
         result_fd, result_path = tempfile.mkstemp(
             suffix="." + filetype, prefix="p3o.report.tmp."
         )


### PR DESCRIPTION
When generating multiple odt files, the extensions of the files in the zip are 'ods' (even if the file is recognized as odt by libreoffice)