### PR TITLE
[14.0] base_comment_template: add templating

### DIFF
--- a/base_comment_template/README.rst
+++ b/base_comment_template/README.rst
@@ -26,7 +26,7 @@ Base Comments Templates
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
 Add a new model to define templates of comments to print on
-documents.
+documents. Templates can use jinja instructions.
 
 Two positions are available for the comments:
 * above document lines
@@ -38,6 +38,11 @@ This module is the base module for following modules:
 * purchase_comment_template
 * invoice_comment_template
 * stock_picking_comment_template
+
+.. note::
+
+  To properly be able to use `${object}` Jinja instructions
+  those modules have to forward current record informations.
 
 **Table of contents**
 

--- a/base_comment_template/readme/DESCRIPTION.rst
+++ b/base_comment_template/readme/DESCRIPTION.rst
@@ -1,5 +1,5 @@
 Add a new model to define templates of comments to print on
-documents.
+documents. Templates can use jinja instructions.
 
 Two positions are available for the comments:
 * above document lines
@@ -11,3 +11,8 @@ This module is the base module for following modules:
 * purchase_comment_template
 * invoice_comment_template
 * stock_picking_comment_template
+
+.. note::
+
+  To properly be able to use `${object}` Jinja instructions
+  those modules have to forward current record informations.

--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -35,3 +35,19 @@ class TestResPartner(TransactionCase):
             self.template_id.get_value(partner_id=partner.id),
             "<p>Testing translated fr_BE</p>",
         )
+
+    def test_get_value_with_partner_model_and_res_id(self):
+        self.env["res.lang"]._activate_lang("fr_BE")
+        partner = self.env.ref("base.res_partner_12")
+        partner.write({"lang": "fr_BE"})
+        self.template_id.with_context(lang="fr_BE").write(
+            {"text": "<p>Testing translated fr_BE `${object.name}`</p>"}
+        )
+        self.assertEqual(
+            self.template_id.get_value(
+                partner_id=partner.id,
+                model="base.comment.template",
+                res_id=self.template_id.id,
+            ),
+            "<p>Testing translated fr_BE `Comment before lines`</p>",
+        )


### PR DESCRIPTION
By this PR I'm proposing to improve `base_comment_template` to be able to use jinja templating on base comments template