### PR TITLE
[13.0][IMP] report_wkhtmltopdf_param: de-duplicate custom params

### DIFF
--- a/report_wkhtmltopdf_param/README.rst
+++ b/report_wkhtmltopdf_param/README.rst
@@ -73,6 +73,7 @@ Contributors
 * Miku Laitinen <miku@avoin.systems>
 * Jordi Ballester <jordi.ballester@eficent.com>
 * Saran Lim. <saranl@ecosoft.co.th>
+* Hai Lang <hailn@trobz.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/report_wkhtmltopdf_param/models/report.py
+++ b/report_wkhtmltopdf_param/models/report.py
@@ -22,6 +22,15 @@ class IrActionsReport(models.Model):
         )
 
         for param in paperformat_id.custom_params:
+            try:
+                value_index = command_args.index(param.name)
+                if param.value:
+                    command_args[value_index + 1] = param.value
+                else:
+                    pass  # param.name is already in command_args
+                continue
+            except ValueError:
+                pass  # param.name is not in command_args
             command_args.extend([param.name])
             if param.value:
                 command_args.extend([param.value])

--- a/report_wkhtmltopdf_param/readme/CONTRIBUTORS.rst
+++ b/report_wkhtmltopdf_param/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Miku Laitinen <miku@avoin.systems>
 * Jordi Ballester <jordi.ballester@eficent.com>
 * Saran Lim. <saranl@ecosoft.co.th>
+* Hai Lang <hailn@trobz.com>

--- a/report_wkhtmltopdf_param/static/description/index.html
+++ b/report_wkhtmltopdf_param/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Report Wkhtmltopdf Param</title>
 <style type="text/css">
 
@@ -421,6 +421,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Miku Laitinen &lt;<a class="reference external" href="mailto:miku&#64;avoin.systems">miku&#64;avoin.systems</a>&gt;</li>
 <li>Jordi Ballester &lt;<a class="reference external" href="mailto:jordi.ballester&#64;eficent.com">jordi.ballester&#64;eficent.com</a>&gt;</li>
 <li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
+<li>Hai Lang &lt;<a class="reference external" href="mailto:hailn&#64;trobz.com">hailn&#64;trobz.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/report_wkhtmltopdf_param/tests/test_report_paperformat.py
+++ b/report_wkhtmltopdf_param/tests/test_report_paperformat.py
@@ -9,25 +9,74 @@ from odoo.exceptions import ValidationError
 @odoo.tests.common.at_install(False)
 @odoo.tests.common.post_install(True)
 class TestWkhtmltopdf(odoo.tests.TransactionCase):
+    def _get_custom_params(self, names, values=None):
+        if type(names) == list:
+            pass
+        else:
+            names = [names]
+        if type(values) == list:
+            pass
+        else:
+            values = [values]
+        params = []
+        for i, name in enumerate(names):
+            try:
+                value = values[i]
+            except IndexError:
+                value = None
+            param = {"name": name}
+            if value is not None:
+                param["value"] = value
+            params.append((0, 0, param))
+        return {"custom_params": params}
+
     def test_wkhtmltopdf_incorrect_parameter(self):
+        name = "bad-parameter"
         for report_paperformat in self.env["report.paperformat"].search([]):
             with self.assertRaises(ValidationError):
-                report_paperformat.update(
-                    {"custom_params": [(0, 0, {"name": "bad-parameter"})]}
-                )
+                report_paperformat.update(self._get_custom_params(name))
 
     def test_wkhtmltopdf_valid_parameter(self):
+        IrActionsReport = self.env["ir.actions.report"]
+        names = ["--dpi", "--disable-smart-shrinking", "--quiet"]
+        values = "360"
+        error_message = "There was an error adding wkhtmltopdf parameter "
         for report_paperformat in self.env["report.paperformat"].search([]):
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat, None
+            )
+            count = len(command_args)
             error = False
             try:
-                report_paperformat.update(
-                    {"custom_params": [(0, 0, {"name": "--disable-smart-shrinking"})]}
-                )
+                report_paperformat.update(self._get_custom_params(names, values))
             except ValidationError:
                 error = True
             self.assertEquals(
-                error,
-                False,
-                "There was an error adding wkhtmltopdf "
-                "parameter --disable-smart-shrinking",
+                error, False, error_message + ", ".join(names),
             )
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat, None
+            )
+            self.assertEquals(count + 1, len(command_args))
+
+    def test_wkhtmltopdf_duplicated_parameter(self):
+        IrActionsReport = self.env["ir.actions.report"]
+        for report_paperformat in self.env["report.paperformat"].search([]):
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat, None,
+            )
+            self.assertEquals(command_args.count("--zoom"), 1)
+            value_index = command_args.index("--zoom") + 1
+            self.assertNotEquals(command_args[value_index], "1.0")
+
+            error = False
+            try:
+                report_paperformat.update(self._get_custom_params("--zoom", "1.0"))
+            except ValidationError:
+                error = True
+            self.assertEquals(error, False)
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat, None,
+            )
+            self.assertEquals(command_args.count("--zoom"), 1)
+            self.assertEquals(command_args[value_index], "1.0")


### PR DESCRIPTION
In case custom paramter (ie. --zoom with value 1.0) is already in
command args list (ie. --zoom with value 0.25), its value should be
updated with custom value (ie. 1.0) instead of having two parameters
with same name.