### PR TITLE
[IMP] - use display for element visibility

### DIFF
--- a/report_qweb_element_page_visibility/views/layouts.xml
+++ b/report_qweb_element_page_visibility/views/layouts.xml
@@ -32,16 +32,16 @@
                         }
                         var operations = {
                             'not-first-page': function (elt) {
-                                elt.style.visibility = (vars.sitepage === vars.frompage) ? "hidden" : "visible";
+                                elt.style.display = (vars.sitepage === vars.frompage) ? "none" : "inherit";
                             },
                             'not-last-page': function (elt) {
-                                elt.style.visibility = (vars.sitepage === vars.sitepages) ? "hidden" : "visible";
+                                elt.style.display = (vars.sitepage === vars.sitepages) ? "none" : "inherit";
                             },
                             'first-page': function (elt) {
-                                elt.style.visibility = (vars.sitepage === vars.frompage) ? "visible" : "hidden";
+                                elt.style.display = (vars.sitepage === vars.frompage) ? "inherit" : "none";
                             },
                             'last-page': function (elt) {
-                                elt.style.visibility = (vars.sitepage === vars.sitepages) ? "visible" : "hidden";
+                                elt.style.display = (vars.sitepage === vars.sitepages) ? "inherit" : "none";
                             },
                         };
                         for (var klass in operations) {


### PR DESCRIPTION
the visibility attribute with the hidden option hides the element but
don't free the space.

A common use case is to have a specific header for the first page and
another for the other pages. With visibility: hidden the second header
cannot take the first one place and will keep a huge margin.
One solution is to use the display:none instead.