### PR TITLE
[FIX] Define search view arch as unicode to make it possible to use non-ascii field descriptions

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -408,14 +408,14 @@ class BiSQLView(models.Model):
             'type': 'search',
             'model': self.model_id.model,
             'arch':
-                """<?xml version="1.0"?>"""
-                """<search string="Analysis">{}"""
-                """<group expand="1" string="Group By">{}</group>"""
-                """</search>""".format(
-                    "".join(
+                u"""<?xml version="1.0"?>"""
+                u"""<search string="Analysis">{}"""
+                u"""<group expand="1" string="Group By">{}</group>"""
+                u"""</search>""".format(
+                    u"".join(
                         [x._prepare_search_field()
                             for x in self.bi_sql_view_field_ids]),
-                    "".join(
+                    u"".join(
                         [x._prepare_search_filter_field()
                             for x in self.bi_sql_view_field_ids]))
         }


### PR DESCRIPTION
Before this fix, a non-ascii character in the field description led to a crash in `_prepare_search_view` as follows:
```
  File "/home/.../reporting-engine/bi_sql_editor/models/bi_sql_view.py", line 278, in button_create_ui
    self._prepare_search_view()).id
  File "/home/.../reporting-engine/bi_sql_editor/models/bi_sql_view.py", line 420, in _prepare_search_view
    for x in self.bi_sql_view_field_ids]))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 193: ordinal not in range(128)

```