### PR TITLE
[14.0][FIX] base_comment_template: Filter domain correctly

### DIFF
--- a/base_comment_template/models/comment_template.py
+++ b/base_comment_template/models/comment_template.py
@@ -39,7 +39,6 @@ class CommentTemplate(models.AbstractModel):
                 ]
             )
             for template in templates:
-                if not template.domain or self in self.search(
-                    safe_eval(template.domain)
-                ):
+                domain = safe_eval(template.domain)
+                if not domain or record.filtered_domain(domain):
                     record.comment_template_ids = [(4, template.id)]


### PR DESCRIPTION
1. Safe eval domain before checking if it is defined. This makes `[]` be `False` on the first check, and provides the proper use case for when the domain is empty
2. Use `filtered_domain` in **record** instead of a `search` in **self**. When on a compute, we are on a `NewId` context, so the search would always fail

@Tecnativa
TT29309

@victoralmau @pedrobaeza please review
I think it would also be needed in v13, can you check @victoralmau?