### PR TITLE
[13.0] report_xlsx: bump development status [ci skip]

### DIFF
--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -7,6 +7,7 @@
     "website": "https://github.com/oca/reporting-engine",
     "category": "Reporting",
     "version": "13.0.1.0.2",
+    "development_status": "Production/Stable",
     "license": "AGPL-3",
     "external_dependencies": {"python": ["xlsxwriter", "xlrd"]},
     "depends": ["base", "web"],


### PR DESCRIPTION
Bump development status of report_xlsx to stable.

It fits the [criteria](odoo-community.org/page/development-status), and mis-builder which already has the stable status depends on it.