### PR TITLE
 [IMP] bi_sql_editor : conserve cron settings, when setting materialized view to draft ; Set correct default values for cron and enable it

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -233,6 +233,8 @@ class BiSQLView(models.Model):
             raise UserError(
                 _("You can only unlink draft views."
                   "If you want to delete them, first set them to draft."))
+        if self.mapped("cron_id"):
+            self.mapped("cron_id").unlink()
         return super(BiSQLView, self).unlink()
 
     @api.multi
@@ -248,10 +250,7 @@ class BiSQLView(models.Model):
     # Action Section
     @api.multi
     def button_create_sql_view_and_model(self):
-        for sql_view in self:
-            if sql_view.state != 'sql_valid':
-                raise UserError(_(
-                    "You can only process this action on SQL Valid items"))
+        for sql_view in self.filtered(lambda x: x.state == "sql_valid"):
             # Create ORM and access
             sql_view._create_model_and_fields()
             sql_view._create_model_access()
@@ -261,32 +260,38 @@ class BiSQLView(models.Model):
             sql_view._create_index()
 
             if sql_view.is_materialized:
-                sql_view.cron_id = self.env['ir.cron'].create(
-                    sql_view._prepare_cron()).id
+                if not sql_view.cron_id:
+                    sql_view.cron_id = self.env['ir.cron'].create(
+                        sql_view._prepare_cron()).id
+                else:
+                    sql_view.cron_id.active = True
             sql_view.state = 'model_valid'
         return True
 
     @api.multi
     def button_set_draft(self):
-        for sql_view in self:
+        for sql_view in self.filtered(lambda x: x.state != "draft"):
             sql_view.menu_id.unlink()
             sql_view.action_id.unlink()
             sql_view.tree_view_id.unlink()
             sql_view.graph_view_id.unlink()
             sql_view.pivot_view_id.unlink()
             sql_view.search_view_id.unlink()
-            if sql_view.cron_id:
-                sql_view.cron_id.unlink()
 
             if sql_view.state in ('model_valid', 'ui_valid'):
                 # Drop SQL View (and indexes by cascade)
                 if sql_view.is_materialized:
                     sql_view._drop_view()
 
+                if sql_view.cron_id:
+                    sql_view.cron_id.active = False
+
                 # Drop ORM
                 sql_view._drop_model_and_fields()
 
-            sql_view.write({'state': 'draft', 'has_group_changed': False})
+            sql_view.has_group_changed = False
+            super(BiSQLView, sql_view).button_set_draft()
+        return True
 
     @api.multi
     def button_create_ui(self):
@@ -358,7 +363,7 @@ class BiSQLView(models.Model):
 
     @api.multi
     def _prepare_cron(self):
-        self.ensure_one()
+        now = datetime.now()
         return {
             'name': _('Refresh Materialized View %s') % self.view_name,
             'user_id': SUPERUSER_ID,
@@ -367,6 +372,10 @@ class BiSQLView(models.Model):
             'state': 'code',
             'code': 'model._refresh_materialized_view_cron(%s)' % self.ids,
             'numbercall': -1,
+            'interval_number': 1,
+            'interval_type': 'days',
+            'nextcall': datetime(now.year, now.month, now.day+1),
+            'active': True,
         }
 
     @api.multi

--- a/bi_sql_editor/tests/test_bi_sql_view.py
+++ b/bi_sql_editor/tests/test_bi_sql_view.py
@@ -82,6 +82,10 @@ class TestBiSqlViewEditor(SingleTransactionCase):
         with self.assertRaises(UserError):
             self.view.unlink()
         self.view.button_set_draft()
+        self.assertNotEqual(
+            self.view.cron_id, False, 'Set to draft materialized view should'
+            ' not unlink cron'
+        )
         self.view.unlink()
         res = self.bi_sql_view.search([('name', '=', 'Partners View 2')])
         self.assertEqual(len(res), 0, 'View not deleted')


### PR DESCRIPTION
Use case : 
- create materialized views, create models and configure the cron
- reset to draft to change request. (adding / removing fields)
- recreate models 

-> the cron settings are lost and has to be set again.

With that patch : 
- cron are kept if materialized views are set to draft
- default run values are now daily at midnight, beginning tomorrow (before was monthly with the datetime of the validation of the view that was making the cron to be refreshed immediately)
- cron is now active by default. (and disabled when view is reset to draft)


CC @quentinDupont 

apps/deck/#/board/144/card/1611