### PR TITLE
[13.0] Remove swig dependency + Copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.1.5
+_commit: v1.2.0
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 dependency_installation_mode: PIP
 generate_requirements_txt: true
@@ -7,18 +7,19 @@ include_wkhtmltopdf: true
 odoo_version: 13.0
 rebel_module_groups: []
 repo_description: 'This repository hosts alternative reporting engines to the ones
-  included on Odoo core (RML, QWeb and Webkit).
+    included on Odoo core (RML, QWeb and Webkit).
 
 
-  The convention is to use a suffix to each module to indicate that it''s for using
-  with that report engine (for example, account_invoice_report_birt or sale_order_report_pentaho).
+    The convention is to use a suffix to each module to indicate that it''s for using
+    with that report engine (for example, account_invoice_report_birt or sale_order_report_pentaho).
 
 
-  It can contain also another utilities directly involved with reports (like merge/split
-  utils, checkers, signing tools and so on).'
+    It can contain also another utilities directly involved with reports (like merge/split
+    utils, checkers, signing tools and so on).'
 repo_name: OCA alternative reporting engines and reporting utilities for Odoo
 repo_slug: reporting-engine
 travis_apt_packages:
 - swig
 - libreoffice
 travis_apt_sources: []
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,74 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 12 * * 0"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # 120+30 day stale policy for PRs
+      # * Except PRs marked as "no stale"
+      - name: Stale PRs policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-pr-labels: "no stale"
+          days-before-stale: 120
+          days-before-close: 30
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          remove-stale-when-updated: true
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request in the past 4 months, so
+            it has been marked as stale and it will be closed automatically if no
+            further activity occurs in the next 30 days.
+
+            If you want this PR to never become stale, please ask a PSC member to apply
+            the "no stale" label.
+
+      # 180+30 day stale policy for open issues
+      # * Except Issues marked as "no stale"
+      - name: Stale Issues policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "no stale,needs more information"
+          days-before-stale: 180
+          days-before-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            There hasn't been any activity on this issue in the past 6 months, so it has
+            been marked as stale and it will be closed automatically if no further
+            activity occurs in the next 30 days.
+
+            If you want this issue to never become stale, please ask a PSC member to
+            apply the "no stale" label.
+
+      # 15+30 day stale policy for issues pending more information
+      # * Issues that are pending more information
+      # * Except Issues marked as "no stale"
+      - name: Needs more information stale issues policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-labels: "needs more information"
+          exempt-issue-labels: "no stale"
+          days-before-stale: 15
+          days-before-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            This issue needs more information and there hasn't been any activity
+            recently, so it has been marked as stale and it will be closed automatically
+            if no further activity occurs in the next 30 days.
+
+            If you think this is a mistake, please ask a PSC member to remove the "needs
+            more information" label.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ py3o.template
 py3o.formats
 genshi>=0.7
 cryptography
-endesive

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,1 @@
+endesive


### PR DESCRIPTION
For `13.0` branches, the `requirements.txt` file is not currently generated from the external dependencies, so we can remove it here.

Also includes a copier update to ensure the template is up to date.