### PR TITLE
[13.0] [IMP] report_qweb_signer: allowed reports on certificate

### DIFF
--- a/report_qweb_signer/README.rst
+++ b/report_qweb_signer/README.rst
@@ -23,7 +23,7 @@ Qweb PDF reports signer
     :target: https://runbot.odoo-community.org/runbot/143/13.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module extends the functionality of report module to sign
 PDFs using a PKCS#12 certificate.

--- a/report_qweb_signer/models/ir_actions_report.py
+++ b/report_qweb_signer/models/ir_actions_report.py
@@ -45,7 +45,13 @@ class IrActionsReport(models.Model):
             if "company_id" in obj:
                 company_id = obj.company_id.id or company_id
         certificates = self.env["report.certificate"].search(
-            [("company_id", "=", company_id), ("model_id", "=", self.model)]
+            [
+                ("company_id", "=", company_id),
+                ("model_id", "=", self.model),
+                "|",
+                ("action_report_ids", "=", False),
+                ("action_report_ids", "in", self.id),
+            ]
         )
         if not certificates:
             return False

--- a/report_qweb_signer/models/report_certificate.py
+++ b/report_qweb_signer/models/report_certificate.py
@@ -36,6 +36,16 @@ class ReportCertificate(models.Model):
     domain = fields.Char(
         string="Domain", help="Domain for filtering if sign or not the document",
     )
+    action_report_ids = fields.Many2many(
+        string="Allowed reports",
+        help="Reports to sign for the selected model."
+        "No report selected means all reports are allowed.",
+        comodel_name="ir.actions.report",
+        relation="report_certificate_action_report",
+        column1="report_certificate_id",
+        column2="action_report_id",
+        domain="[('model_id', '=', model_id)]",
+    )
     allow_only_one = fields.Boolean(
         string="Allow only one document",
         default=True,

--- a/report_qweb_signer/readme/ROADMAP.rst
+++ b/report_qweb_signer/readme/ROADMAP.rst
@@ -2,3 +2,6 @@
   then 'Save as attachment' is not applied and signed result is not
   saved as attachment.
 * Add tests.
+* Why not taking the occasion to add the whole configuration at report level
+  (if to be signed or not, the domain, etc...)?
+  See https://github.com/OCA/reporting-engine/pull/533#issuecomment-898321161

--- a/report_qweb_signer/views/report_certificate_view.xml
+++ b/report_qweb_signer/views/report_certificate_view.xml
@@ -33,6 +33,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 widget="selection"
                                 groups="base.group_multi_company"
                             />
+                            <field name="action_report_ids" widget="many2many_tags" />
                         </group>
                         <group
                             attrs="{'invisible': [('signing_method', '!=', 'endesive')]}"


### PR DESCRIPTION
Add a new 'Allowed reports' field on the certificate. Only reports listed in this field can be signed. No report means all reports are allowed.