### PR TITLE
[ADD] 'single-page' and 'multi-page' classes in report_qweb_element_p…

### DIFF
--- a/report_qweb_element_page_visibility/views/layouts.xml
+++ b/report_qweb_element_page_visibility/views/layouts.xml
@@ -43,6 +43,12 @@
                             'last-page': function (elt) {
                                 elt.style.visibility = (vars.sitepage === vars.sitepages) ? "visible" : "hidden";
                             },
+                            'single-page': function (elt) {
+                                elt.style.display = (vars.sitepages === 1) ? "inherit" : "none";
+                            },
+                            'multi-page': function (elt) {
+                                elt.style.display = (vars.sitepages > 1) ? "inherit" : "none";
+                            },
                         };
                         for (var klass in operations) {
                             var y = document.getElementsByClassName(klass);


### PR DESCRIPTION
…age_visibility module

These classes cause the element to be visible when the document is only a single page long (for single-page) or when it's multiple pages long (for multi-page). This is especially useful for page counters, which can be hidden when there's only a single page.