### PR TITLE
[FIX-OU] report_py3o: Missing migration script

### DIFF
--- a/report_py3o/migrations/13.0.1.0.0/post-migration.py
+++ b/report_py3o/migrations/13.0.1.0.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2020 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr, """SELECT id, py3o_template_data FROM py3o_template"""
+    )
+    templates = env.cr.fetchall()
+    for template_id, data in templates:
+        template = env["py3o.template"].browse(template_id)
+        template.write({"py3o_template_data": bytes(data)})


### PR DESCRIPTION
Binary fields on 13 are by default attachments:

https://github.com/odoo/odoo/blob/13.0/odoo/fields.py#L1900

It is different on 12.0:

https://github.com/odoo/odoo/blob/12.0/odoo/fields.py#L1853

So, we need to overwrite it in order to fix it.