### PR TITLE
[FIX] report_xlsx: correctly handle exceptions, when generating report

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -4,7 +4,8 @@
 import json
 import time
 
-from odoo.http import content_disposition, request, route
+from odoo.http import content_disposition, request, route, serialize_exception
+from odoo.tools import html_escape
 from odoo.tools.safe_eval import safe_eval
 
 from odoo.addons.web.controllers import main as report
@@ -14,6 +15,13 @@ class ReportController(report.ReportController):
     @route()
     def report_routes(self, reportname, docids=None, converter=None, **data):
         if converter == "xlsx":
+            return self._report_routes_xlsx(reportname, docids, converter, **data)
+        return super(ReportController, self).report_routes(
+            reportname, docids, converter, **data
+        )
+
+    def _report_routes_xlsx(self, reportname, docids=None, converter=None, **data):
+        try:
             report = request.env["ir.actions.report"]._get_report_from_name(reportname)
             context = dict(request.env.context)
             if docids:
@@ -45,6 +53,7 @@ class ReportController(report.ReportController):
                 ("Content-Disposition", content_disposition(report_name + ".xlsx")),
             ]
             return request.make_response(xlsx, headers=xlsxhttpheaders)
-        return super(ReportController, self).report_routes(
-            reportname, docids, converter, **data
-        )
+        except Exception as e:
+            se = serialize_exception(e)
+            error = {"code": 200, "message": "Odoo Server Error", "data": se}
+            return request.make_response(html_escape(json.dumps(error)))

--- a/report_xlsx/readme/CONTRIBUTORS.rst
+++ b/report_xlsx/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Graeme Gellatly <gdgellatly@gmail.com>
 * Cristian Salamea <cs@prisehub.com>
 * Rod Schouteden <rod.schouteden@dynapps.be>
+* Eugene Molotov <molotov@it-projects.info>


### PR DESCRIPTION
Before this commit, when exception is raised while generating report,
on browser window instead of python traceback nothing was shown
on production environment or werkzeug's "Console locked" message
on development environment.

Fixes https://github.com/OCA/reporting-engine/issues/513