### PR TITLE
[IMP][12.0] bi_sql_editor : use ace widget

### DIFF
--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -69,7 +69,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     </group>
                     <notebook>
                         <page string="SQL Query">
-                            <field name="query" nolabel="1" colspan="4" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            <field name="query" nolabel="1" colspan="4" attrs="{'readonly': [('state', '!=', 'draft')]}" widget="ace"/>
                         </page>
                         <page string="SQL Fields" attrs="{'invisible': [('state', '=', 'draft')]}">
                             <field name="bi_sql_view_field_ids" nolabel="1" colspan="4" attrs="{'readonly': [('state', '!=', 'sql_valid')]}">


### PR DESCRIPTION
## Before

- display : 
![image](https://user-images.githubusercontent.com/3407482/146519426-97d40c98-0c84-4e5e-934e-cda9da82899e.png)
- "tab" doesn't work.

## After

- display : 
![image](https://user-images.githubusercontent.com/3407482/146519521-fdd9d6c4-4e35-4ec5-ad1c-be0fe370eff2.png)
- "tab" key works !

CC : 
- other contributors : @tfossoul, @vnahaulogy, @hbrunn
- @mariadforgeflow could you include this trivial change in your V15 PR ? https://github.com/OCA/reporting-engine/pull/557
- @quentinDupont 

Note : unfortunately, In V12 (at least) it is not possible to use syntaxic color with something like ``options="{'mode': 'sql'}"`` (unlike for xml, because ace javascript lib doesn't seems to be complete in ``web`` module)