### PR TITLE
[14.0][FIX] report_qweb_encrypt: conflict with bank statement

### DIFF
--- a/report_qweb_encrypt/models/ir_actions_report.py
+++ b/report_qweb_encrypt/models/ir_actions_report.py
@@ -34,6 +34,8 @@ class IrActionsReport(models.Model):
         document, ttype = super(IrActionsReport, self)._render_qweb_pdf(
             res_ids=res_ids, data=data
         )
+        if isinstance(res_ids, int):
+            res_ids = [res_ids]
         password = self._get_pdf_password(res_ids[:1])
         document = self._encrypt_pdf(document, password)
         return document, ttype


### PR DESCRIPTION
This pull request is used to fix an error when **Validate** a bank statement.

### Step to error:

1. Install account and report_qweb_encrypt
2. Create and reconcile a bank statement
3. **Validate** a bank statement

![Selection_082](https://user-images.githubusercontent.com/51266019/148492457-6d2ceb0d-bd97-447c-86f9-5beda0119885.png)




