### PR TITLE
[FIX] report_xlsx: fix generation of pdf reports

### DIFF
--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "ACSONE SA/NV," "Creu Blanca," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/reporting-engine",
     "category": "Reporting",
-    "version": "15.0.1.0.1",
+    "version": "15.0.1.0.2",
     "development_status": "Production/Stable",
     "license": "AGPL-3",
     "external_dependencies": {"python": ["xlsxwriter", "xlrd"]},

--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -24,16 +24,16 @@ _logger = logging.getLogger(__name__)
 class ReportController(report.ReportController):
     @route()
     def report_routes(self, reportname, docids=None, converter=None, **data):
-        report = request.env["ir.actions.report"]._get_report_from_name(reportname)
-        context = dict(request.env.context)
-        if docids:
-            docids = [int(i) for i in docids.split(",")]
-        if data.get("options"):
-            data.update(json.loads(data.pop("options")))
-        if data.get("context"):
-            data["context"] = json.loads(data["context"])
-            context.update(data["context"])
         if converter == "xlsx":
+            report = request.env["ir.actions.report"]._get_report_from_name(reportname)
+            context = dict(request.env.context)
+            if docids:
+                docids = [int(i) for i in docids.split(",")]
+            if data.get("options"):
+                data.update(json.loads(data.pop("options")))
+            if data.get("context"):
+                data["context"] = json.loads(data["context"])
+                context.update(data["context"])
             xlsx = report.with_context(**context)._render_xlsx(docids, data=data)[0]
             xlsxhttpheaders = [
                 (

--- a/report_xlsx/static/src/js/report/action_manager_report.esm.js
+++ b/report_xlsx/static/src/js/report/action_manager_report.esm.js
@@ -48,6 +48,7 @@ registry
             } else if (onClose) {
                 onClose();
             }
+            return Promise.resolve(true);
         }
-        return Promise.resolve(true);
+        return Promise.resolve(false);
     });


### PR DESCRIPTION
the report handler for xlsx added in report_xlsx module is always returning `true` even if the report being
generated is not xlsx. Due to this, the report handler doesn't check for other report types
at [action_service.js#L1019](https://github.com/odoo/odoo/blob/b309d3a99f8ff4a43a21c4772c344ed3250e319f/addons/web/static/src/webclient/actions/action_service.js#L1019) and thus doesn't generate any other reports. So if the converter is not xlsx,
return false instead of true.

Also, updating the docids and context in the report_routes controller only needs to be done if
the converter is xlsx and not in any other case.