### PR TITLE
[14.0][FW][IMP] report_wkhtmltopdf_param: de-duplicate custom params

### DIFF
--- a/report_wkhtmltopdf_param/models/report.py
+++ b/report_wkhtmltopdf_param/models/report.py
@@ -22,8 +22,17 @@ class IrActionsReport(models.Model):
         )
 
         for param in paperformat_id.custom_params:
-            command_args.extend([param.name])
+            try:
+                value_index = command_args.index(param.name)
+            except ValueError:
+                value_index = len(command_args)
+                command_args.extend([param.name])
             if param.value:
-                command_args.extend([param.value])
+                try:
+                    command_args[value_index + 1] = param.value
+                except IndexError:
+                    command_args.extend([param.value])
+            else:
+                pass  # param.name is already in command_args
 
         return command_args

--- a/report_wkhtmltopdf_param/readme/CONTRIBUTORS.rst
+++ b/report_wkhtmltopdf_param/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Jordi Ballester <jordi.ballester@eficent.com>
 * Saran Lim. <saranl@ecosoft.co.th>
 * Foram Shah <foramshah@initos.com>
+* Hai Lang <hailn@trobz.com>

--- a/report_wkhtmltopdf_param/tests/test_report_paperformat.py
+++ b/report_wkhtmltopdf_param/tests/test_report_paperformat.py
@@ -9,25 +9,78 @@ from odoo.tests.common import tagged
 
 @tagged("post_install", "-at_install")
 class TestWkhtmltopdf(odoo.tests.TransactionCase):
+    def _get_custom_params(self, names, values=None):
+        if type(names) == list:
+            pass
+        else:
+            names = [names]
+        if type(values) == list:
+            pass
+        else:
+            values = [values]
+        params = []
+        for i, name in enumerate(names):
+            try:
+                value = values[i]
+            except IndexError:
+                value = None
+            param = {"name": name}
+            if value is not None:
+                param["value"] = value
+            params.append((0, 0, param))
+        return {"custom_params": params}
+
     def test_wkhtmltopdf_incorrect_parameter(self):
+        name = "bad-parameter"
         for report_paperformat in self.env["report.paperformat"].search([]):
             with self.assertRaises(ValidationError):
-                report_paperformat.update(
-                    {"custom_params": [(0, 0, {"name": "bad-parameter"})]}
-                )
+                report_paperformat.update(self._get_custom_params(name))
 
     def test_wkhtmltopdf_valid_parameter(self):
+        IrActionsReport = self.env["ir.actions.report"]
+        names = ["--dpi", "--disable-smart-shrinking", "--quiet"]
+        values = "360"
+        error_message = "There was an error adding wkhtmltopdf parameter "
         for report_paperformat in self.env["report.paperformat"].search([]):
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat, None
+            )
+            count = len(command_args)
             error = False
             try:
-                report_paperformat.update(
-                    {"custom_params": [(0, 0, {"name": "--disable-smart-shrinking"})]}
-                )
+                report_paperformat.update(self._get_custom_params(names, values))
             except ValidationError:
                 error = True
-            self.assertEquals(
+            self.assertEqual(
                 error,
                 False,
-                "There was an error adding wkhtmltopdf "
-                "parameter --disable-smart-shrinking",
+                error_message + ", ".join(names),
             )
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat, None
+            )
+            self.assertEqual(count + 1, len(command_args))
+
+    def test_wkhtmltopdf_duplicated_parameter(self):
+        IrActionsReport = self.env["ir.actions.report"]
+        for report_paperformat in self.env["report.paperformat"].search([]):
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat,
+                None,
+            )
+            self.assertEqual(command_args.count("--zoom"), 1)
+            value_index = command_args.index("--zoom") + 1
+            self.assertNotEqual(command_args[value_index], "1.0")
+
+            error = False
+            try:
+                report_paperformat.update(self._get_custom_params("--zoom", "1.0"))
+            except ValidationError:
+                error = True
+            self.assertEqual(error, False)
+            command_args = IrActionsReport._build_wkhtmltopdf_args(
+                report_paperformat,
+                None,
+            )
+            self.assertEqual(command_args.count("--zoom"), 1)
+            self.assertEqual(command_args[value_index], "1.0")


### PR DESCRIPTION
Avoid duplicated parameters when adding custom ones
In case custom paramter (ie. --zoom with value 1.0) is already in
command args list (ie. --zoom with value 0.25), its value should be
updated with custom value (ie. 1.0) instead of having two parameters
with same name.