### PR TITLE
[14.0] IMP: bi_sql_editor lang handling

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -716,7 +716,7 @@ class BiSQLView(models.Model):
                 # Alter name of the action, to display last refresh
                 # datetime of the materialized view
                 sql_view.action_id.with_context(
-                    lang=self.env.user.lang
+                    lang=self.env.context.get("lang", self.env.user.lang)
                 ).name = sql_view._prepare_action_name()
 
     def _refresh_size(self):


### PR DESCRIPTION
Allow to call refresh materialized view with an explicit lang passed in
the context and have this get priority over the user's lang