### PR TITLE
[13.0][IMP] base_comment_template: Promote to mature

### DIFF
--- a/base_comment_template/__manifest__.py
+++ b/base_comment_template/__manifest__.py
@@ -12,6 +12,7 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["base", "mail"],
+    "development_status": "Mature",
     "data": [
         "security/ir.model.access.csv",
         "security/security.xml",


### PR DESCRIPTION
It complies with the rules and it's needed for dependant modules.