### PR TITLE
[FIX] report_xlsx: fixed file name

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -36,7 +36,7 @@ class ReportController(report.ReportController):
                     del data["context"]["lang"]
                 context.update(data["context"])
             xlsx = report.with_context(context)._render_xlsx(docids, data=data)[0]
-            report_name = report.report_file
+            report_name = report.name
             if report.print_report_name and not len(docids) > 1:
                 obj = request.env[report.model].browse(docids[0])
                 report_name = safe_eval(report.print_report_name, {"object": obj})


### PR DESCRIPTION
Let's not be different.
File name should not be a technical name of the report record. 
Isn't `report_file` field even depreciated? 