### PR TITLE
[FIX] report_xlsx: Fix dynamic report download

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -90,9 +90,10 @@ class ReportController(report.ReportController):
                             report.print_report_name, {"object": obj, "time": time}
                         )
                         filename = "%s.%s" % (report_name, "xlsx")
-                response.headers.add(
-                    "Content-Disposition", content_disposition(filename)
-                )
+                if not response.headers.get("Content-Disposition"):
+                    response.headers.add(
+                        "Content-Disposition", content_disposition(filename)
+                    )
                 return response
             else:
                 return super(ReportController, self).report_download(data, context)


### PR DESCRIPTION
Fix dynamic report download issue.

Download failed because of the dynamic report doesn't have report action and that's why the filename set false and the report can't be downloaded

@ForgeFlow