### PR TITLE
[FIX] report_xml: pass context data in controller

### DIFF
--- a/report_xml/controllers/main.py
+++ b/report_xml/controllers/main.py
@@ -92,4 +92,4 @@ class ReportController(report.ReportController):
                 error = {"code": 200, "message": "Odoo Server Error", "data": se}
                 return request.make_response(html_escape(json.dumps(error)))
         else:
-            return super().report_download(data, token, context)
+            return super().report_download(data, token, context=context)


### PR DESCRIPTION
Context in report_download is optional gives an error as if we passed more parameters