### PR TITLE
[14.0][FIX] report_qweb_signer: Fix TypeError

### DIFF
--- a/report_qweb_signer/models/ir_actions_report.py
+++ b/report_qweb_signer/models/ir_actions_report.py
@@ -40,6 +40,8 @@ class IrActionsReport(models.Model):
             return False
         company_id = self.env.company.id
         if res_ids:
+            if isinstance(res_ids, int):
+                res_ids = [res_ids]
             obj = self.env[self.model].browse(res_ids[0])
             if "company_id" in obj:
                 company_id = obj.company_id.id or company_id

--- a/report_qweb_signer/readme/CONTRIBUTORS.rst
+++ b/report_qweb_signer/readme/CONTRIBUTORS.rst
@@ -7,3 +7,6 @@
     * David Vidal
 * Santi Argüeso <santi@comunitea.com>
 * Omar Castiñeira <omar@comunitea.com>
+* `Punt Sistemes <https://www.puntsistemes.es>`_:
+
+    * Isaac Gallart <igallart@puntsistemes.es>


### PR DESCRIPTION
TypeError: 'int' object is not subscriptable

When you sign the picking, it fails:
```

File "/opt/odoo/src/core/addons/account/models/ir_actions_report.py", line 50, in _render_qweb_pdf
    return super()._render_qweb_pdf(res_ids=res_ids, data=data)
  File "/opt/odoo/src/reporting-engine/report_qweb_signer/models/ir_actions_report.py", line 204, in _render_qweb_pdf
    certificate = self._certificate_get(res_ids)
  File "/opt/odoo/src/reporting-engine/report_qweb_signer/models/ir_actions_report.py", line 43, in _certificate_get
    obj = self.env[self.model].browse(res_ids[0])
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/src/core/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/src/core/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: 'int' object is not subscriptable
```

![imagen](https://user-images.githubusercontent.com/13520529/198309456-b72a168e-7204-4e24-844c-e09a2e27f293.png)

