### PR TITLE
[16.0][FIX] base_comment_template: Add models text field to prevent error from ir.model model

### DIFF
--- a/base_comment_template/__manifest__.py
+++ b/base_comment_template/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Base Comments Templates",
     "summary": "Add conditional mako template to any report"
     "on models that inherits comment.template.",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "Reporting",
     "website": "https://github.com/OCA/reporting-engine",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/base_comment_template/i18n/base_comment_template.pot
+++ b/base_comment_template/i18n/base_comment_template.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-11-03 08:01+0000\n"
+"PO-Revision-Date: 2022-11-03 08:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -196,6 +198,7 @@ msgstr ""
 
 #. module: base_comment_template
 #: model:ir.model,name:base_comment_template.model_ir_model
+#: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template__models
 msgid "Models"
 msgstr ""
 
@@ -254,6 +257,12 @@ msgstr ""
 #. module: base_comment_template
 #: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template__sequence
 msgid "Sequence"
+msgstr ""
+
+#. module: base_comment_template
+#: code:addons/base_comment_template/models/base_comment_template.py:0
+#, python-format
+msgid "Some model (%s) not found"
 msgstr ""
 
 #. module: base_comment_template

--- a/base_comment_template/i18n/es.po
+++ b/base_comment_template/i18n/es.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-09 09:55+0000\n"
-"PO-Revision-Date: 2021-02-09 11:21+0100\n"
+"POT-Creation-Date: 2022-11-03 08:01+0000\n"
+"PO-Revision-Date: 2022-11-03 09:03+0100\n"
 "Last-Translator: Carlos <carlos.roca@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: base_comment_template
 #: model_terms:ir.ui.view,arch_db:base_comment_template.base_comment_template_preview_form
@@ -65,7 +65,7 @@ msgstr ""
 #. module: base_comment_template
 #: model:ir.model.fields.selection,name:base_comment_template.selection__base_comment_template__position__after_lines
 msgid "Bottom"
-msgstr ""
+msgstr "Abajo"
 
 #. module: base_comment_template
 #: model_terms:ir.ui.view,arch_db:base_comment_template.base_comment_template_preview_form
@@ -134,7 +134,7 @@ msgstr "Creado el"
 #. module: base_comment_template
 #: model_terms:ir.ui.view,arch_db:base_comment_template.base_comment_template_preview_form
 msgid "Discard"
-msgstr ""
+msgstr "Descartar"
 
 #. module: base_comment_template
 #: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template__display_name
@@ -201,10 +201,11 @@ msgstr "Última modificación el"
 #. module: base_comment_template
 #: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template_preview__model_id
 msgid "Model"
-msgstr ""
+msgstr "Modelo"
 
 #. module: base_comment_template
 #: model:ir.model,name:base_comment_template.model_ir_model
+#: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template__models
 msgid "Models"
 msgstr "Modelos"
 
@@ -223,7 +224,7 @@ msgstr "Nombre de la plantilla de comentario"
 #. module: base_comment_template
 #: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template_preview__no_record
 msgid "No Record"
-msgstr ""
+msgstr "Sin registro"
 
 #. module: base_comment_template
 #: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template__partner_ids
@@ -238,12 +239,12 @@ msgstr "Posición en el documento"
 #. module: base_comment_template
 #: model_terms:ir.ui.view,arch_db:base_comment_template.view_base_comment_template_form
 msgid "Preview"
-msgstr ""
+msgstr "Previsualizar"
 
 #. module: base_comment_template
 #: model_terms:ir.ui.view,arch_db:base_comment_template.base_comment_template_preview_form
 msgid "Preview of"
-msgstr ""
+msgstr "Previsualización de"
 
 #. module: base_comment_template
 #: model:ir.model.fields.selection,name:base_comment_template.selection__base_comment_template_preview__engine__qweb
@@ -263,7 +264,13 @@ msgstr ""
 #. module: base_comment_template
 #: model:ir.model.fields,field_description:base_comment_template.field_base_comment_template__sequence
 msgid "Sequence"
-msgstr ""
+msgstr "Secuencia"
+
+#. module: base_comment_template
+#: code:addons/base_comment_template/models/base_comment_template.py:0
+#, python-format
+msgid "Some model (%s) not found"
+msgstr "Algún modelo (%s) no se ha encontrado"
 
 #. module: base_comment_template
 #: model:ir.model.fields,help:base_comment_template.field_res_partner__base_comment_template_ids
@@ -349,4 +356,4 @@ msgstr ""
 #. module: base_comment_template
 #: model_terms:ir.ui.view,arch_db:base_comment_template.base_comment_template_preview_form
 msgid "record:"
-msgstr ""
+msgstr "registro:"

--- a/base_comment_template/migrations/16.0.1.1.0/pre-migration.py
+++ b/base_comment_template/migrations/16.0.1.1.0/pre-migration.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+from odoo.tools.sql import column_exists
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not column_exists(env.cr, "base_comment_template", "models"):
+        openupgrade.logged_query(
+            env.cr,
+            "ALTER TABLE base_comment_template ADD COLUMN IF NOT EXISTS models text",
+        )
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE base_comment_template template
+            SET models = (
+                SELECT string_agg(model.model, ',')
+                FROM base_comment_template_ir_model_rel AS rel
+                JOIN ir_model AS model ON rel.ir_model_id = model.id
+                WHERE rel.base_comment_template_id = template.id
+            )
+            """,
+        )

--- a/base_comment_template/views/base_comment_template_view.xml
+++ b/base_comment_template/views/base_comment_template_view.xml
@@ -10,7 +10,8 @@
                 <field name="position" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="partner_ids" />
-                <field name="model_ids" />
+                <field name="models" />
+                <field name="model_ids" groups="base.group_erp_manager" />
                 <field name="domain" />
             </tree>
         </field>
@@ -24,7 +25,8 @@
                 <field name="position" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="partner_ids" />
-                <field name="model_ids" />
+                <field name="models" />
+                <field name="model_ids" groups="base.group_erp_manager" />
                 <field name="domain" />
                 <field name="sequence" />
             </search>
@@ -67,7 +69,7 @@
                                 groups="base.group_multi_company"
                             />
                             <field name="domain" />
-                            <field name="model_ids" widget="many2many_tags" />
+                            <field name="models" />
                             <field name="partner_ids" widget="many2many_tags" />
                         </group>
                     </group>


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/reporting-engine/pull/677

Add models text field to prevent error from `ir.model` model

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT40209