### PR TITLE
[12.0][FIX] report_csv: remove csv external dependency

### DIFF
--- a/report_csv/__manifest__.py
+++ b/report_csv/__manifest__.py
@@ -10,11 +10,6 @@
     'category': 'Reporting',
     'version': '12.0.1.0.0',
     'license': 'AGPL-3',
-    'external_dependencies': {
-        'python': [
-            'csv',
-        ],
-    },
     'depends': [
         'base', 'web',
     ],


### PR DESCRIPTION
Currently, the `report_csv` module cannot be installed through the OCA package index due to an external dependency to the non-existent `csv` package, which (at least according to the [documentation](https://docs.python.org/3.6/library/csv.html)) has been a builtin python library for a long time.

This can be reproduced within the `oca-ci` docker image:
```shell
docker run --rm -it ghcr.io/oca/oca-ci/py3.6-odoo12.0:latest \
pip install odoo12-addon-report-csv
```
Which generates the following error:
```
Looking in indexes: https://wheelhouse.odoo-community.org/oca-simple-and-pypi                                                                                                          
Collecting odoo12-addon-report-csv                                                                                                                                                     
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo12-addon-report-csv/odoo12_addon_report_csv-12.0.1.0.0.99.dev3-py3-none-any.whl (29 kB)                             
Requirement already satisfied: odoo<12.1dev,>=12.0a in /opt/odoo (from odoo12-addon-report-csv) (12.0)                                                                                 
  Downloading https://wheelhouse.odoo-community.org/oca-simple/odoo12-addon-report-csv/odoo12_addon_report_csv-12.0.1.0.0.99.dev2-py3-none-any.whl (29 kB)                             
ERROR: Cannot install odoo12-addon-report-csv==12.0.1.0.0.99.dev2 and odoo12-addon-report-csv==12.0.1.0.0.99.dev3 because these package versions have conflicting dependencies.        
                                                                                                                                                                                       
The conflict is caused by:                                                                                                                                                             
    odoo12-addon-report-csv 12.0.1.0.0.99.dev3 depends on csv                                                                                                                          
    odoo12-addon-report-csv 12.0.1.0.0.99.dev2 depends on csv
```

The issue can be easily solved by removing the [csv external dependency](https://github.com/OCA/reporting-engine/blob/80087e8f1da4ba2feccf39dfc13f27dca15730d7/report_csv/__manifest__.py#L15), but I guess someone would need to actually rebuild and upload the wheel to the index, perhaps @sbidoul? Additionally, the same issue seems to exist in the [11.0 branch](https://github.com/OCA/reporting-engine/blob/27aa0c5ddfbde1fd4d27481e297d5e121029e0d8/report_csv/__manifest__.py#L15).