### PR TITLE
[16.0][IMP] report_xml: Added `xml_extension`

### DIFF
--- a/report_xml/controllers/report.py
+++ b/report_xml/controllers/report.py
@@ -70,7 +70,7 @@ class ReportController(report.ReportController):
                     report_name = safe_eval(
                         report.print_report_name, {"object": obj, "time": time}
                     )
-                    filename = f"{report_name}.xml"
+                    filename = f"{report_name}.{report.xml_extension}"
             else:
                 data = url_parse(url).decode_query(cls=dict)
                 if "context" in data:
@@ -80,7 +80,7 @@ class ReportController(report.ReportController):
                 response = self.report_routes(
                     reportname, converter="xml", context=context, **data
                 )
-            filename = filename or f"{report.name}.xml"
+            filename = filename or f"{report.name}.{report.xml_extension}"
             response.headers.add("Content-Disposition", content_disposition(filename))
             return response
         except Exception as e:

--- a/report_xml/models/ir_actions_report.py
+++ b/report_xml/models/ir_actions_report.py
@@ -29,6 +29,10 @@ class IrActionsReport(models.Model):
         help='Add `<?xml encoding="..." version="..."?>` at the start of final report '
         "file.",
     )
+    xml_extension = fields.Char(
+        default="xml",
+        help="Extension for XML Reports, by default is `xml`",
+    )
 
     @api.model
     def _render_qweb_xml(self, report_ref, res_ids, data=None):

--- a/report_xml/tests/test_report_xml.py
+++ b/report_xml/tests/test_report_xml.py
@@ -1,12 +1,15 @@
 # Copyright 2017 Creu Blanca
 # License AGPL-3.0 or later (https://www.gnuorg/licenses/agpl).
 
+import json
+
 from lxml import etree
 
+from odoo import http
 from odoo.tests import common
 
 
-class TestXmlReport(common.TransactionCase):
+class TestXmlReport(common.HttpCase):
     def test_xml(self):
         report_object = self.env["ir.actions.report"]
         report_name = "report_xml.demo_report_xml_view"
@@ -17,3 +20,28 @@ class TestXmlReport(common.TransactionCase):
         result_tree = etree.fromstring(result_report[0])
         el = result_tree.xpath("/root/user/name")
         self.assertEqual(el[0].text, docs.ensure_one().name)
+
+    def test_xml_extension(self):
+        self.authenticate("admin", "admin")
+        report_object = self.env["ir.actions.report"]
+        report_name = "report_xml.demo_report_xml_view"
+        report = report_object._get_report(report_name)
+        # Test changing report to use ".svg" extension
+        report.write({"xml_extension": "svg"})
+        filename = self.get_report_headers().headers.get("Content-Disposition")
+        self.assertTrue(".svg" in filename)
+        # Test changing report to use ".ffdata" extension
+        report.write({"xml_extension": "ffdata"})
+        filename = self.get_report_headers().headers.get("Content-Disposition")
+        self.assertTrue(".ffdata" in filename)
+
+    def get_report_headers(self):
+        return self.url_open(
+            url="/report/download",
+            data={
+                "data": json.dumps(
+                    ["/report/xml/report_xml.demo_report_xml_view/1", "qweb-xml"]
+                ),
+                "csrf_token": http.Request.csrf_token(self),
+            },
+        )

--- a/report_xml/views/ir_actions_report_view.xml
+++ b/report_xml/views/ir_actions_report_view.xml
@@ -24,6 +24,7 @@
                 >
                     <field name="xsd_schema" />
                     <field name="xml_encoding" />
+                    <field name="xml_extension" />
                     <field name="xml_declaration" />
                 </group>
             </xpath>


### PR DESCRIPTION
Adds a way to choose the file extension for your XML file, by adding the flexibility of appending more choices. For example, instead of getting `.xml`, this allows to have the report download as `.svg` or even good old `.html` if needed. This is also very useful for some localization purposes, where some scarce software uses uncommon file extensions for their XML files, like `.ffdata` for specific accounting reports here in Lithuania.

The change is not breaking, as we set the default to be `.xml` like it was by default anyway.

