### PR TITLE
[FIX] kpi_dashboard: Fix reaccessing and url

### DIFF
--- a/kpi_dashboard/models/kpi_dashboard.py
+++ b/kpi_dashboard/models/kpi_dashboard.py
@@ -63,6 +63,7 @@ class KpiDashboard(models.Model):
     def read_dashboard(self):
         self.ensure_one()
         result = {
+            "id": self.id,
             "name": self.name,
             "width": self.width,
             "item_ids": self.item_ids.read_dashboard(),

--- a/kpi_dashboard/static/src/js/dashboard_controller.js
+++ b/kpi_dashboard/static/src/js/dashboard_controller.js
@@ -46,12 +46,11 @@ odoo.define("kpi_dashboard.DashboardController", function (require) {
             });
             this._super($node, options);
         },
-        _pushState: function (state) {
-            // eslint-disable-next-line no-param-reassign
-            state = state || {};
-            var env = this.model.get(this.handle, {env: true});
+        getState: function () {
+            const state = this._super.apply(this, arguments);
+            const env = this.model.get(this.handle, {env: true});
             state.id = env.currentId;
-            this._super(state);
+            return state;
         },
         _addDashboard: function () {
             var self = this;

--- a/kpi_dashboard/static/src/js/dashboard_model.js
+++ b/kpi_dashboard/static/src/js/dashboard_model.js
@@ -4,16 +4,20 @@ odoo.define("kpi_dashboard.DashboardModel", function (require) {
     var BasicModel = require("web.BasicModel");
 
     var DashboardModel = BasicModel.extend({
-        _fetchRecord: function (record) {
+        _fetchRecord: function (record, options) {
+            var self = this;
             return this._rpc({
                 model: record.model,
                 method: "read_dashboard",
                 args: [[record.res_id]],
                 context: _.extend({}, record.getContext(), {bin_size: true}),
-            }).then(function (result) {
-                record.specialData = result;
-                return result;
-            });
+            })
+                .then(function (result) {
+                    record.specialData = result;
+                })
+                .then(function () {
+                    return self._postprocess(record, options);
+                });
         },
     });
 

--- a/kpi_dashboard/static/src/js/dashboard_view.js
+++ b/kpi_dashboard/static/src/js/dashboard_view.js
@@ -23,7 +23,7 @@ odoo.define("kpi_dashboard.DashboardView", function (require) {
             Model: DashboardModel,
         }),
         multi_record: false,
-        searchable: false,
+        withSearchBar: false,
         init: function () {
             this._super.apply(this, arguments);
             this.controllerParams.mode = "readonly";


### PR DESCRIPTION
I found two bugs:

The first one was raised if you accessed  `Dashboards / Configure Dashboard` Selected a dashboard changes view, goes backs to the form view and you try to open the dashboard view again.

The second one, was that the id was not kept on the url. Now it is fixed.