### PR TITLE
[FIX] report_xlsx: initialize reportname

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -52,6 +52,7 @@ class ReportController(ReportController):
     def report_download(self, data, context=None, token=None):
         requestcontent = json.loads(data)
         url, report_type = requestcontent[0], requestcontent[1]
+        reportname = "???"
         try:
             if report_type == "xlsx":
                 reportname = url.split("/report/xlsx/")[1].split("?")[0]


### PR DESCRIPTION
without it we get traceback instead of exception when trying to print invoice report:

Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 1990, in __call__
    response = request._serve_db()
  File "/odoo/src/odoo/http.py", line 1584, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/odoo/src/odoo/service/model.py", line 134, in retrying
    result = func()
  File "/odoo/src/odoo/http.py", line 1613, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/odoo/src/odoo/http.py", line 1726, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/odoo/external-src/odoo-cloud-platform/monitoring_prometheus/models/ir_http.py", line 38, in _dispatch
    res = super()._dispatch(endpoint)
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 149, in _dispatch
    result = endpoint(**request.params)
  File "/odoo/src/odoo/http.py", line 699, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/odoo/external-src/reporting-engine/report_xlsx/controllers/main.py", line 101, in report_download
    _logger.exception("Error while generating report %s", reportname)
UnboundLocalError: local variable 'reportname' referenced before assignment
