### PR TITLE
[FIX] base_comment_template: Prevent access error when comments are associated to multiple models

### DIFF
--- a/base_comment_template/models/base_comment_template.py
+++ b/base_comment_template/models/base_comment_template.py
@@ -119,6 +119,6 @@ class BaseCommentTemplate(models.Model):
     def _search_model_ids(self, operator, value):
         # We cannot use model_ids.model in search() method to avoid access errors
         allowed_items = (
-            self.sudo().search([]).filtered(lambda x: x.model_ids.model == value)
+            self.sudo().search([]).filtered(lambda x: value in x.mapped('model_ids.model'))
         )
         return [("id", "in", allowed_items.ids)]


### PR DESCRIPTION
Prevents an access error in the _search_model_ids method when searching through comments associated with multiple model types.