### PR TITLE
[REF] report_qweb_pdf_watermark: remove PyPDF2 from

### DIFF
--- a/report_py3o/__manifest__.py
+++ b/report_py3o/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/reporting-engine",
     "depends": ["web"],
     "external_dependencies": {
-        "python": ["py3o.template", "py3o.formats", "PyPDF2"],
+        "python": ["py3o.template", "py3o.formats"],
         "deb": ["libreoffice"],
     },
     "data": [

--- a/report_qweb_pdf_watermark/__manifest__.py
+++ b/report_qweb_pdf_watermark/__manifest__.py
@@ -16,5 +16,4 @@
     ],
     "demo": ["demo/report.xml"],
     "installable": True,
-    "external_dependencies": {"python": ["PyPDF2"]},
 }

--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -9,7 +9,6 @@
     "version": "13.0.1.1.0",
     "development_status": "Production/Stable",
     "license": "AGPL-3",
-    "external_dependencies": {"python": ["xlsxwriter", "xlrd"]},
     "depends": ["base", "web"],
     "data": ["views/webclient_templates.xml"],
     "demo": ["demo/report.xml"],

--- a/report_xml/__manifest__.py
+++ b/report_xml/__manifest__.py
@@ -20,10 +20,5 @@
         "demo/report.xml",  # register report in the system
         "demo/demo_report.xml",  # report body definition
     ],
-    "external_dependencies": {
-        "python": [  # Python third party libraries required for module
-            "lxml"  # XML and HTML with Python
-        ]
-    },
     "post_init_hook": "post_init_hook",
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ endesive
 lxml
 py3o.formats
 py3o.template
-xlrd
-xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ endesive
 lxml
 py3o.formats
 py3o.template
-PyPDF2
 xlrd
 xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # generated from manifests external_dependencies
 cryptography
 endesive
-lxml
 py3o.formats
 py3o.template


### PR DESCRIPTION
external_dependencies

Because those dependencies are already part of Odoo's base dependencies.

https://github.com/odoo/odoo/blob/0aff8bb9484a23c0d875d3b12259dd4e0d51e716/requirements.txt#L38


Cherry-pick from https://github.com/OCA/reporting-engine/pull/623