### PR TITLE
[15.0][FIX] report_xlsx: make sure variable is known

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -52,9 +52,9 @@ class ReportController(report.ReportController):
     def report_download(self, data, context=None):
         requestcontent = json.loads(data)
         url, report_type = requestcontent[0], requestcontent[1]
+        reportname = url.split("/report/xlsx/")[1].split("?")[0]
         try:
             if report_type == "xlsx":
-                reportname = url.split("/report/xlsx/")[1].split("?")[0]
                 docids = None
                 if "/" in reportname:
                     reportname, docids = reportname.split("/")


### PR DESCRIPTION
Before this commit if another app crashes the "report_xlsx" controller it would go into the exception. However in the exception the following is called:
_logger.exception("Error while generating report %s", reportname)

As the except clause does not have the "reportname" variable it fails: Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/odoo/src/odoo/odoo/http.py", line 804, in dispatch
    r = self._call_function(**self.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/odoo/src/odoo/odoo/http.py", line 910, in __call__
    return self.method(*args, **kw)
  File "/home/odoo/src/odoo/odoo/http.py", line 535, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/src/user/report_xlsx/controllers/main.py", line 100, in report_download
    _logger.exception("Error while generating report %s", reportname)
Exception

By putting the "reportname" before the try it will always be available & the real cause will show