### PR TITLE
[FIX][15.0] report_xlsx - IndexError

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -52,9 +52,10 @@ class ReportController(report.ReportController):
     def report_download(self, data, context=None):
         requestcontent = json.loads(data)
         url, report_type = requestcontent[0], requestcontent[1]
-        reportname = url.split("/report/xlsx/")[1].split("?")[0]
-        try:
-            if report_type == "xlsx":
+        if report_type == "xlsx":
+            reportname = url
+            try:
+                reportname = url.split("/report/xlsx/")[1].split("?")[0]
                 docids = None
                 if "/" in reportname:
                     reportname, docids = reportname.split("/")
@@ -95,10 +96,9 @@ class ReportController(report.ReportController):
                         "Content-Disposition", content_disposition(filename)
                     )
                 return response
-            else:
-                return super(ReportController, self).report_download(data, context)
-        except Exception as e:
-            _logger.exception("Error while generating report %s", reportname)
-            se = _serialize_exception(e)
-            error = {"code": 200, "message": "Odoo Server Error", "data": se}
-            return request.make_response(html_escape(json.dumps(error)))
+            except Exception as e:
+                _logger.exception("Error while generating report %s", reportname)
+                se = _serialize_exception(e)
+                error = {"code": 200, "message": "Odoo Server Error", "data": se}
+                return request.make_response(html_escape(json.dumps(error)))
+        return super(ReportController, self).report_download(data, context)


### PR DESCRIPTION
IndexError thrown when attempting to split url by /report/xlsx when you are not printing a XLSX report.

This issue was introduced by #751 

As per the comments from etobella I've moved the try catch inside the if statement and provided a fallback of the full URL.

As far as I can tell this seems to be the least painful solution? I'm assuming there's no private information in the report URL?