### PR TITLE
[13.0][FIX] base_comment_template: Consider multi-company and partners

### DIFF
--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -1,5 +1,6 @@
 # Copyright 2020 NextERP Romania SRL
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tests import common
 
@@ -7,9 +8,6 @@ from .fake_models import ResUsers, setup_test_model, teardown_test_model
 
 
 class TestCommentTemplate(common.SavepointCase):
-    at_install = False
-    post_install = True
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -37,10 +35,6 @@ class TestCommentTemplate(common.SavepointCase):
                 "company_id": cls.company.id,
             }
         )
-        cls.user.partner_id.base_comment_template_ids = [
-            (4, cls.before_template_id.id),
-            (4, cls.after_template_id.id),
-        ]
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
In a multi-company context, if you put a template with company_id set, this template is trying to be assigned to any document, no matter which company it belongs, as it runs in a sudo environment, or at least, you can have several companies seen at the same time.

We add the company discriminant for avoiding this problem.

Furthermore, the previous code was adding a domain where the right part may be `False` with the operator `in`, provoking an unexpected behavior in the search.

This has been fixed stating directly the expected domain.

@Tecnativa TT42591