### PR TITLE
[14.0][FIX] base_comment_template: Consider multi-company and partners

### DIFF
--- a/base_comment_template/models/comment_template.py
+++ b/base_comment_template/models/comment_template.py
@@ -2,6 +2,7 @@
 # Copyright 2013-2014 Nicolas Bessi (Camptocamp SA)
 # Copyright 2020 NextERP Romania SRL
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, fields, models
 from odoo.tools.safe_eval import safe_eval
@@ -31,17 +32,25 @@ class CommentTemplate(models.AbstractModel):
     def _compute_comment_template_ids(self):
         for record in self:
             partner = record[self._comment_template_partner_field_name]
-            record.comment_template_ids = [(5,)]
-            templates = self.env["base.comment.template"].search(
-                [
-                    ("id", "in", partner.base_comment_template_ids.ids),
-                    ("model_ids.model", "=", self._name),
+            domain = [
+                "|",
+                ("partner_ids", "=", False),
+                ("partner_ids", "=", partner.id),
+                ("model_ids.model", "=", self._name),
+            ]
+            if "company_id" in self._fields:
+                domain += [
+                    "|",
+                    ("company_id", "=", False),
+                    ("company_id", "=", record.company_id.id),
                 ]
-            )
+            templates = self.env["base.comment.template"].search(domain)
             for template in templates:
                 domain = safe_eval(template.domain)
                 if not domain or record.filtered_domain(domain):
                     record.comment_template_ids = [(4, template.id)]
+            if not templates:
+                record.comment_template_ids = False
 
     def render_comment(
         self, comment, engine="jinja", add_context=None, post_process=False

--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -1,5 +1,6 @@
 # Copyright 2020 NextERP Romania SRL
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tests import common
 from odoo.tools.misc import mute_logger
@@ -18,14 +19,12 @@ class TestCommentTemplate(common.SavepointCase):
         cls.partner_id = cls.env.ref("base.res_partner_12")
         cls.partner2_id = cls.env.ref("base.res_partner_10")
         cls.ResPartnerTitle = cls.env["res.partner.title"]
-        cls.main_company = cls.env.ref("base.main_company")
-        cls.company = cls.env["res.company"].create({"name": "Test company"})
         cls.before_template_id = cls.env["base.comment.template"].create(
             {
                 "name": "Top template",
                 "text": "Text before lines",
                 "model_ids": [(6, 0, cls.user_obj.ids)],
-                "company_id": cls.company.id,
+                "company_id": False,
             }
         )
         cls.after_template_id = cls.env["base.comment.template"].create(
@@ -34,13 +33,9 @@ class TestCommentTemplate(common.SavepointCase):
                 "position": "after_lines",
                 "text": "Text after lines",
                 "model_ids": [(6, 0, cls.user_obj.ids)],
-                "company_id": cls.company.id,
+                "company_id": False,
             }
         )
-        cls.user.partner_id.base_comment_template_ids = [
-            (4, cls.before_template_id.id),
-            (4, cls.after_template_id.id),
-        ]
 
     @classmethod
     def tearDownClass(cls):

--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -3,7 +3,6 @@
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tests import common
-from odoo.tools.misc import mute_logger
 
 from .fake_models import ResUsers, setup_test_model, teardown_test_model
 
@@ -94,12 +93,7 @@ class TestCommentTemplate(common.SavepointCase):
             )
 
     def test_render_comment_text_(self):
-        with mute_logger("odoo.addons.base.models.ir_translation"):
-            self.env["base.language.install"].create(
-                {"lang": "ro_RO", "overwrite": True}
-            ).lang_install()
-        with mute_logger("odoo.tools.translate"):
-            self.env["base.update.translations"].create({"lang": "ro_RO"}).act_update()
+        self.env["res.lang"]._activate_lang("ro_RO")
         partner_title = self.ResPartnerTitle.create(
             {"name": "Ambassador", "shortcut": "Amb."}
         )


### PR DESCRIPTION
Forward-port of #754 

In a multi-company context, if you put a template with company_id set, this template is trying to be assigned to any document, no matter which company it belongs, as it runs in a sudo environment, or at least, you can have several companies seen at the same time.

We add the company discriminant for avoiding this problem.

Furthermore, the previous code was adding a domain where the right part may be `False` with the operator `in`, provoking an unexpected behavior in the search.

This has been fixed stating directly the expected domain.

@Tecnativa TT42591