### PR TITLE
[14.0][FIX] report_qweb_signer: remove `cryptography` from depends

### DIFF
--- a/report_qweb_signer/__manifest__.py
+++ b/report_qweb_signer/__manifest__.py
@@ -14,7 +14,7 @@
     "installable": True,
     "depends": ["web_editor"],
     "external_dependencies": {
-        "python": ["endesive", "cryptography"],
+        "python": ["endesive"],
         "deb": ["default-jre-headless"],
     },
     "data": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # generated from manifests external_dependencies
-cryptography
 endesive
 py3o.formats
 py3o.template


### PR DESCRIPTION
Such dependency is already included in Odoo requirements using a pinned version. Adding here could cause to upgrade the library to an incompatible version.