### PR TITLE
[16][FIX] sql_export_mail : sql users need read right on cron to access the query

### DIFF
--- a/sql_export_mail/__manifest__.py
+++ b/sql_export_mail/__manifest__.py
@@ -13,6 +13,7 @@
     ],
     "license": "AGPL-3",
     "data": [
+        "security/ir.model.access.csv",
         "views/sql_export_view.xml",
         "data/mail_template.xml",
     ],

--- a/sql_export_mail/security/ir.model.access.csv
+++ b/sql_export_mail/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_read_cron_sql_user","access_read_cron_sql_user","base.model_ir_cron",sql_request_abstract.group_sql_request_user,1,0,0,0
+"access_read_actions_server_sql_user","access_read_actions_server_sql_user","base.model_ir_actions_server",sql_request_abstract.group_sql_request_user,1,0,0,0

--- a/sql_export_mail/views/sql_export_view.xml
+++ b/sql_export_mail/views/sql_export_view.xml
@@ -10,6 +10,7 @@
                 <button
                     name="create_cron"
                     string="Create Cron"
+                    groups="sql_request_abstract.group_sql_request_manager"
                     type="object"
                     attrs="{'invisible': ['|', ('state', '=', 'draft'), ('mail_user_ids', '=', [(6, False, [])])]}"
                 />


### PR DESCRIPTION
@legalsylvain One more patch needed for sql_export_mail in v16.
The users have to be able to read the cron model to be able to access a sql report, since it maybe linked to a cron to be sent by email automatically.