### PR TITLE
[15.0][FIX] base_comment_template: Fix access error

### DIFF
--- a/base_comment_template/models/base_comment_template.py
+++ b/base_comment_template/models/base_comment_template.py
@@ -113,7 +113,7 @@ class BaseCommentTemplate(models.Model):
                 item.name, dict(self._fields["position"].selection).get(item.position)
             )
             if self.env.context.get("comment_template_model_display"):
-                name += " (%s)" % ", ".join(item.model_ids.mapped("name"))
+                name += " (%s)" % ", ".join(item.sudo().model_ids.mapped("name"))
             res.append((item.id, name))
         return res
 


### PR DESCRIPTION
When using the base comment template feature on contacts (res_partner), when a user without admin rights tries to open up the form view of an affected contact, he gets an access error because he doesn't have the necessary rights to read the fields from 'ir_model'.

This adjustment fixes that.
