### PR TITLE
[15.0][FIX] base_comment_template: search when multiple models in a template

### DIFF
--- a/base_comment_template/models/base_comment_template.py
+++ b/base_comment_template/models/base_comment_template.py
@@ -120,6 +120,8 @@ class BaseCommentTemplate(models.Model):
     def _search_model_ids(self, operator, value):
         # We cannot use model_ids.model in search() method to avoid recursion.
         allowed_items = (
-            self.sudo().search([]).filtered(lambda x: x.model_ids.model == value)
+            self.sudo()
+            .search([])
+            .filtered(lambda x: value in x.model_ids.mapped("model"))
         )
         return [("id", "in", allowed_items.ids)]

--- a/base_comment_template/models/comment_template.py
+++ b/base_comment_template/models/comment_template.py
@@ -24,7 +24,7 @@ class CommentTemplate(models.AbstractModel):
         compute_sudo=True,
         comodel_name="base.comment.template",
         string="Comment Template",
-        domain=lambda self: [("model_ids", "=", self._name)],
+        domain=lambda self: [("model_ids", "in", self._name)],
         store=True,
         readonly=False,
     )
@@ -32,7 +32,7 @@ class CommentTemplate(models.AbstractModel):
     @api.depends(_comment_template_partner_field_name)
     def _compute_comment_template_ids(self):
         template_model = self.env["base.comment.template"]
-        template_domain = template_model._search_model_ids("=", self._name)
+        template_domain = template_model._search_model_ids("in", self._name)
         for record in self:
             partner = record[self._comment_template_partner_field_name]
             record.comment_template_ids = [(5,)]


### PR DESCRIPTION
I have comment templates that are shared between several models:

![image](https://github.com/OCA/reporting-engine/assets/19620251/c77118a8-b43d-494d-a7c8-48af8c802095)

I think the module allows to do so in the specifications and the _search_model_ids method needs to change it will output an error

@ForgeFlow
