### PR TITLE
[16.0][IMP] base_comment_template: allow to show code view in text field

### DIFF
--- a/base_comment_template/views/base_comment_template_view.xml
+++ b/base_comment_template/views/base_comment_template_view.xml
@@ -75,7 +75,7 @@
                     </group>
                     <notebook>
                         <page name="text" string="Comment">
-                            <field name="text" />
+                            <field name="text" options="{'codeview': true}" />
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
This change allows to see code view in the comment definition, to allow to copy structure from hml code.

<img width="649" alt="Captura de pantalla 2023-08-21 a la(s) 5 07 44 p m" src="https://github.com/OCA/reporting-engine/assets/6758279/c05c998c-a4b5-463b-8abd-d34b28308c7c">
