### PR TITLE
[IMP] Avoiding ERROR in log with tests of report_qweb_pdf_watermark

### DIFF
--- a/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
+++ b/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
@@ -51,7 +51,10 @@ class TestReportQwebPdfWatermark(HttpCase):
         # test 0
         numpages = 0
         # pdf_has_usable_pages(self, pdf_watermark)
-        self.assertFalse(self.env["ir.actions.report"].pdf_has_usable_pages(numpages))
+        with self.assertLogs(level="ERROR"):
+            self.assertFalse(
+                self.env["ir.actions.report"].pdf_has_usable_pages(numpages)
+            )
         # test 1
         numpages = 1
         self.assertTrue(self.env["ir.actions.report"].pdf_has_usable_pages(numpages))


### PR DESCRIPTION
When having 0 pages it will raise and error
https://github.com/BT-rmartin/reporting-engine/blob/16.0-1/report_qweb_pdf_watermark/models/report.py#L56
We are in this way adding a context manager to test that at least one error message is logged on the logger with at least the given level.