### PR TITLE
[16.0][IMP] base_comment_template: allow to select rendering engine

### DIFF
--- a/base_comment_template/models/base_comment_template.py
+++ b/base_comment_template/models/base_comment_template.py
@@ -72,6 +72,16 @@ class BaseCommentTemplate(models.Model):
     sequence = fields.Integer(
         required=True, default=10, help="The smaller number = The higher priority"
     )
+    engine = fields.Selection(
+        selection=[
+            ("inline_template", "Inline Template"),
+            ("qweb", "QWeb"),
+            ("qweb_view", "QWeb View"),
+        ],
+        required=True,
+        default="inline_template",
+        help="This field allows to select the engine to use for rendering the template.",
+    )
 
     def _get_ir_model_items(self, models):
         return (

--- a/base_comment_template/models/comment_template.py
+++ b/base_comment_template/models/comment_template.py
@@ -50,14 +50,14 @@ class CommentTemplate(models.AbstractModel):
                     record.comment_template_ids = [(4, template.id)]
 
     def render_comment(
-        self, comment, engine="inline_template", add_context=None, post_process=False
+        self, comment, engine=False, add_context=None, post_process=False
     ):
         self.ensure_one()
         comment_texts = self.env["mail.render.mixin"]._render_template(
             template_src=comment.text,
             model=self._name,
             res_ids=[self.id],
-            engine=engine,
+            engine=engine or comment.engine,
             add_context=add_context,
             post_process=post_process,
         )

--- a/base_comment_template/views/base_comment_template_view.xml
+++ b/base_comment_template/views/base_comment_template_view.xml
@@ -71,6 +71,7 @@
                             <field name="domain" />
                             <field name="models" />
                             <field name="partner_ids" widget="many2many_tags" />
+                            <field name="engine" groups="base.group_no_one" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
I made this PR based on comment https://github.com/OCA/sale-reporting/pull/227#issuecomment-1696503543

I have added a new field `engine` to allow to set the engine that will be used to render the template.

- I have set the default engine to `inline_template` in order to not break current installations.
- I updated the method `render_comment ` to work as it was designed and if the engine is nos passed to the method it will take the one from the template in order to not break current installations.
- I have added the field `engine` in the view only shown with developer mode.