### PR TITLE
[16][IMP] sql_export : Direct download when executing the query instead of showing wizard

### DIFF
--- a/sql_export/wizard/wizard_file.py
+++ b/sql_export/wizard/wizard_file.py
@@ -63,11 +63,12 @@ class SqlFileWizard(models.TransientModel):
                 % {"name": sql_export.name, "date": date, "extension": extension},
             }
         )
-        return {
-            "view_mode": "form",
-            "res_model": "sql.file.wizard",
-            "res_id": self.id,
-            "type": "ir.actions.act_window",
-            "target": "new",
-            "context": self.env.context,
+        action = {
+            "name": "SQL Export",
+            "type": "ir.actions.act_url",
+            "url": "web/content/?model=%s&id=%d&filename_field=filename&"
+            "field=binary_file&download=true&filename=%s"
+            % (self._name, self.id, self.file_name),
+            "target": "self",
         }
+        return action

--- a/sql_export/wizard/wizard_file_view.xml
+++ b/sql_export/wizard/wizard_file_view.xml
@@ -12,13 +12,6 @@
                     hideKanbanOption="1"
                     required="1"
                 />
-                    <separator
-                    string="Export file"
-                    colspan="4"
-                    attrs="{'invisible': [('binary_file', '=', False)]}"
-                />
-                    <field name="binary_file" filename="file_name" />
-                    <field name="file_name" invisible="1" />
                     <field name="sql_export_id" invisible="1" />
                     <footer>
                         <button


### PR DESCRIPTION
It is more practical (one less click)

It also fixes a warning we currently have : 
`WARNING XXX odoo.http: <function odoo.addons.web.controllers.binary.content_common> called ignoring args {'data', 'token'}`

@legalsylvain 