### PR TITLE
[FIX] report_qweb_encrypt: Use _get_report instead of _get_report_from_name

### DIFF
--- a/report_qweb_encrypt/models/ir_actions_report.py
+++ b/report_qweb_encrypt/models/ir_actions_report.py
@@ -31,7 +31,7 @@ class IrActionsReport(models.Model):
         )
         if res_ids:
             encrypt_password = self._context.get("encrypt_password")
-            report = self._get_report_from_name(reportname).with_context(
+            report = self._get_report(reportname).with_context(
                 encrypt_password=encrypt_password
             )
             password = report._get_pdf_password(res_ids[:1])


### PR DESCRIPTION
reportname is not only a string but also a model or integer, the method _get_report handles those cases to return the report.