### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -309,7 +309,9 @@ class Py3oReport(models.TransientModel):
         attachment = existing_reports_attachment.get(model_instance.id)
         if attachment and self.ir_actions_report_id.attachment_use:
             content = base64.b64decode(attachment.datas)
-            fd, report_file = tempfile.mkstemp("." + self.ir_actions_report_id.py3o_filetype)
+            fd, report_file = tempfile.mkstemp(
+                "." + self.ir_actions_report_id.py3o_filetype
+            )
             os.close(fd)
             with open(report_file, "wb") as f:
                 f.write(content)

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -309,7 +309,8 @@ class Py3oReport(models.TransientModel):
         attachment = existing_reports_attachment.get(model_instance.id)
         if attachment and self.ir_actions_report_id.attachment_use:
             content = base64.b64decode(attachment.datas)
-            report_file = tempfile.mktemp("." + self.ir_actions_report_id.py3o_filetype)
+            fd, report_file = tempfile.mkstemp("." + self.ir_actions_report_id.py3o_filetype)
+            os.close(fd)
             with open(report_file, "wb") as f:
                 f.write(content)
             return report_file
@@ -318,7 +319,8 @@ class Py3oReport(models.TransientModel):
     def _zip_results(self, reports_path):
         self.ensure_one()
         zfname_prefix = self.ir_actions_report_id.name
-        result_path = tempfile.mktemp(suffix="zip", prefix="py3o-zip-result")
+        fd, result_path = tempfile.mkstemp(suffix="zip", prefix="py3o-zip-result")
+        os.close(fd)
         with ZipFile(result_path, "w", ZIP_DEFLATED) as zf:
             cpt = 0
             for report in reports_path:


### PR DESCRIPTION
## Details
> In file: [py30_report.py](https://github.com/OCA/reporting-engine/blob/16.0/report_py3o/models/py3o_report.py#L321), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


#### Resources Related to `mktemp`
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)


## Changes
- Replaced `mktemp()` method with `mkstemp()`


## Previously Found & Fixed
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
