### PR TITLE
[15.0][FIX][bi_sql_editor] unlink bi_sql_view without cron

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -158,6 +158,7 @@ class BiSQLView(models.Model):
         comodel_name="ir.cron",
         readonly=True,
         help="Cron Task that will refresh the materialized view",
+        ondelete="cascade",
     )
 
     rule_id = fields.Many2one(string="Odoo Rule", comodel_name="ir.rule", readonly=True)
@@ -259,7 +260,6 @@ class BiSQLView(models.Model):
                     "If you want to delete them, first set them to draft."
                 )
             )
-        self.cron_id.unlink()
         return super(BiSQLView, self).unlink()
 
     def copy(self, default=None):


### PR DESCRIPTION
It isn't possible to unlink a bi sql view if there isn't a CRON related to it.
A fix has been done in 16.0: https://github.com/OCA/reporting-engine/pull/770

But letting the ORM handling the unlink doesn't require the line of code.

@PierrickBrun @legalsylvain A review is welcome