### PR TITLE
IMP: bi_sql_editor raise UserError when matching on field is not found

### DIFF
--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -168,6 +168,13 @@ class BiSQLViewField(models.Model):
             many2one_model_id = (
                 self.env["ir.model"].search([("model", "=", model_name)]).id
             )
+            if not many2one_model_id:
+                raise UserError(
+                    _(
+                        "There is no relation matching for the field %s",
+                        field_without_prefix,
+                    )
+                )
 
         vals.update(
             {


### PR DESCRIPTION
When creating a new SQL view, if the naming is not met you end with that have an invalid definition.
`ttype: many2one, many2one_model_id: ` => the model is not found.

This will lead to errors when trying to load the tree view

The goal here is to raise an error and warn the user about it.

```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/odoo/src/odoo/http.py", line 687, in dispatch
    result = self._call_function(**self.params)
  File "/odoo/src/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/odoo/src/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/odoo/src/odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/odoo/src/odoo/http.py", line 916, in __call__
    return self.method(*args, **kw)
  File "/odoo/src/odoo/http.py", line 535, in response_wrap
    response = f(*args, **kw)
  File "/odoo/src/addons/web/controllers/main.py", line 1300, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
  File "/odoo/src/addons/web/controllers/main.py", line 1319, in do_search_read
    return Model.web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
  File "/odoo/src/addons/web/models/models.py", line 62, in web_search_read
    records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
  File "/odoo/src/odoo/models.py", line 5050, in search_read
    result = records.read(fields, **read_kwargs)
  File "/odoo/src/odoo/models.py", line 3227, in read
    return self._read_format(fnames=fields, load=load)
  File "/odoo/src/odoo/models.py", line 3247, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "/odoo/src/odoo/fields.py", line 2808, in convert_to_read
    return (value.id, value.sudo().display_name)
ExceptionThe above exception was the direct cause of the following exception:Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: '_unknown' object has no attribute 'id'
 ```
