### PR TITLE
[16][FIX] sql_export : remove unused action parameter

### DIFF
--- a/sql_export/models/sql_export.py
+++ b/sql_export/models/sql_export.py
@@ -50,7 +50,6 @@ class SqlExport(models.Model):
             "res_id": wiz.id,
             "type": "ir.actions.act_window",
             "context": self.env.context,
-            "nodestroy": True,
         }
 
     def export_sql_query(self):


### PR DESCRIPTION
Same as here : https://github.com/OCA/reporting-engine/pull/766

But it has been introduced again by mistake by https://github.com/OCA/reporting-engine/pull/718, which was merged after the PR 766...