### PR TITLE
[12.0][ADD] Py3o report signer

### DIFF
--- a/report_py3o_signer/__init__.py
+++ b/report_py3o_signer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/report_py3o_signer/__manifest__.py
+++ b/report_py3o_signer/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 fah-mili/Lambdao
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Py3o PDF reports signer',
+    'summary': 'Sign Py3o PDFs using a PKCS#12 certificate',
+    'version': '12.0.1.0.0',
+    'category': 'Reporting',
+    'license': 'AGPL-3',
+    'author': 'Lambdao, Odoo Community Association (OCA)',
+    "website": "https://github.com/OCA/reporting-engine",
+    'depends': ['report_py3o', 'report_qweb_signer'],
+    'data': [],
+    'installable': True,
+}

--- a/report_py3o_signer/models/__init__.py
+++ b/report_py3o_signer/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/report_py3o_signer/models/ir_actions_report.py
+++ b/report_py3o_signer/models/ir_actions_report.py
@@ -1,0 +1,27 @@
+# Copyright 2023 fah-mili/Lambdao
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class IrActionsReport(models.Model):
+
+    _inherit = 'ir.actions.report'
+
+    def _signable_report(self):
+        """Necessary to get the certificate with py3o reports"""
+        is_py3o_signable = self.report_type == 'py3o' and self.py3o_filetype == 'pdf'
+        return is_py3o_signable or super()._signable_report()
+
+    def render_py3o(self, res_ids=None, data=None):
+        certificate = self._certificate_get(res_ids)
+        signed_content, ext = self._read_attached_signed_content(res_ids, certificate)
+        if signed_content:
+            return signed_content, 'pdf'
+        content, ext = super(IrActionsReport, self).render_py3o(res_ids, data)
+        if certificate:
+            content = self._sign_pdf_and_attach(res_ids, certificate, content)
+        return content, ext

--- a/report_py3o_signer/readme/CONTRIBUTORS.rst
+++ b/report_py3o_signer/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* `Lambdao <https://lambdao.dev>`_:
+
+    * Fanny He
+    * Nans Lefebvre

--- a/report_py3o_signer/readme/DESCRIPTION.rst
+++ b/report_py3o_signer/readme/DESCRIPTION.rst
@@ -1,0 +1,6 @@
+This module extends the functionality of report module to sign
+PDFs using a PKCS#12 certificate.
+
+This module extends the functionality the pdf report signing to py3o reports.
+Please refer to the documentation of `report_py3o` for how to configure such reports.
+Please refer to the documentation of `report_qweb_signer` for how to configure certificates for signing; such certificate will be used for any py3o report if its output is configured to be in pdf.

--- a/report_py3o_signer/tests/__init__.py
+++ b/report_py3o_signer/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_report_py3o_signer

--- a/report_py3o_signer/tests/test_report_py3o_signer.py
+++ b/report_py3o_signer/tests/test_report_py3o_signer.py
@@ -1,0 +1,41 @@
+# Copyright 2023 fah-mili/Lambdao
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestReportPy3oSignerCase(TransactionCase):
+    def setUp(self):
+        super(TestReportPy3oSignerCase, self).setUp()
+        self.user = self.env.ref('base.user_admin')
+        self.report = self.env.ref(
+            'report_py3o.res_users_report_py3o'
+        ).with_context(force_report_rendering=True)
+        self.report.py3o_filetype = 'pdf'
+        self.report.attachment_use = True
+        self.report.attachment = "'test_' + (object.name or '') + '.pdf'"
+
+        user_model = self.env['ir.model'].search([('model', '=', 'res.users')])
+        self.certificate = self.env.ref('report_qweb_signer.demo_certificate_test')
+        self.certificate.model_id = user_model
+        self.certificate.domain = "[]"
+
+
+class TestReportPy3oSigner(TestReportPy3oSignerCase):
+    def test_report_py3o_signer(self):
+        user_ids = self.user.ids
+        self.report.render_py3o(user_ids)
+        # we should find the saved signed content
+        signed_content = self.report._attach_signed_read(user_ids, self.certificate)
+        self.assertTrue(signed_content)
+
+        # Reprint again for taking the PDF from attachment
+        IrAttachment = self.env['ir.attachment']
+        domain = [
+            ('res_id', '=', self.user.id),
+            ('res_model', '=', self.user._name),
+        ]
+        num_attachments = IrAttachment.search_count(domain)
+        self.report.render_py3o(user_ids)
+        num_attachments_after = IrAttachment.search_count(domain)
+        self.assertEqual(num_attachments, num_attachments_after)

--- a/report_qweb_signer/models/ir_actions_report.py
+++ b/report_qweb_signer/models/ir_actions_report.py
@@ -30,9 +30,13 @@ def _normalize_filepath(path):
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
+    def _signable_report(self):
+        """Return whether the report is signable or not."""
+        return self.report_type == 'qweb-pdf'
+
     def _certificate_get(self, res_ids):
         """Obtain the proper certificate for the report and the conditions."""
-        if self.report_type != 'qweb-pdf':
+        if not self._signable_report():
             return False
         certificates = self.env['report.certificate'].search([
             ('company_id', '=', self.env.user.company_id.id),

--- a/setup/report_py3o_signer/odoo/addons/report_py3o_signer
+++ b/setup/report_py3o_signer/odoo/addons/report_py3o_signer
@@ -1,0 +1,1 @@
+../../../../report_py3o_signer

--- a/setup/report_py3o_signer/setup.py
+++ b/setup/report_py3o_signer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This new module brings the PKCS signing to py3o pdf reports.

There's a very small refactoring in qweb signer to help reduce code duplication. 