### PR TITLE
[16.0][IMP] bi_sql_editor

### DIFF
--- a/bi_sql_editor/demo/bi_sql_view_demo.xml
+++ b/bi_sql_editor/demo/bi_sql_view_demo.xml
@@ -20,6 +20,7 @@ ORDER BY unexisting_field
     <record id="partner_sql_view" model="bi.sql.view">
         <field name="name">Partners View</field>
         <field name="technical_name">partners_view</field>
+        <field name="is_materialized" eval="True" />
         <field
             name="query"
         ><![CDATA[

--- a/bi_sql_editor/demo/bi_sql_view_demo.xml
+++ b/bi_sql_editor/demo/bi_sql_view_demo.xml
@@ -49,19 +49,4 @@ FROM ir_module_module
 ]]>
             </field>
     </record>
-    <function
-        model="bi.sql.view"
-        name="button_validate_sql_expression"
-        eval="([ref('module_sql_view')])"
-    />
-    <function
-        model="bi.sql.view"
-        name="button_create_sql_view_and_model"
-        eval="([ref('module_sql_view')])"
-    />
-    <function
-        model="bi.sql.view"
-        name="button_create_ui"
-        eval="([ref('module_sql_view')])"
-    />
 </odoo>

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -269,12 +269,10 @@ class BiSQLView(models.Model):
     def copy(self, default=None):
         self.ensure_one()
         default = dict(default or {})
-        default.update(
-            {
-                "name": _("%s (Copy)") % self.name,
-                "technical_name": "%s_copy" % self.technical_name,
-            }
-        )
+        if "name" not in default:
+            default["name"] = _("%s (Copy)") % self.name
+        if "technical_name" not in default:
+            default["technical_name"] = f"{self.technical_name}_copy"
         return super().copy(default=default)
 
     # Action Section

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from psycopg2 import ProgrammingError
 
 from odoo import SUPERUSER_ID, _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools import sql, table_columns
 from odoo.tools.safe_eval import safe_eval
 
@@ -278,6 +278,15 @@ class BiSQLView(models.Model):
     # Action Section
     def button_create_sql_view_and_model(self):
         for sql_view in self.filtered(lambda x: x.state == "sql_valid"):
+            # Check if many2one fields are correctly
+            bad_fields = sql_view.bi_sql_view_field_ids.filtered(
+                lambda x: x.ttype == "many2one" and not x.many2one_model_id.id
+            )
+            if bad_fields:
+                raise ValidationError(
+                    _("Please set related models on the following fields %s")
+                    % ",".join(bad_fields.mapped("name"))
+                )
             # Create ORM and access
             sql_view._create_model_and_fields()
             sql_view._create_model_access()

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -169,12 +169,6 @@ class BiSQLView(models.Model):
 
     sequence = fields.Integer(string="sequence")
 
-    option_context_field = fields.Boolean(
-        string="Use Context Field",
-        help="Check this box if you want to add a context column in the field list view."
-        " Custom Context will be inserted in the created views.",
-    )
-
     # Constrains Section
     @api.constrains("is_materialized")
     def _check_index_materialized(self):

--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -70,31 +70,40 @@ class BiSQLViewField(models.Model):
         string="SQL View", comodel_name="bi.sql.view", ondelete="cascade"
     )
 
+    state = fields.Selection(related="bi_sql_view_id.state", store=True)
+
     is_index = fields.Boolean(
         help="Check this box if you want to create"
         " an index on that field. This is recommended for searchable and"
         " groupable fields, to reduce duration",
+        states={"model_valid": [("readonly", True)], "ui_valid": [("readonly", True)]},
     )
 
     is_group_by = fields.Boolean(
         string="Is Group by",
         help="Check this box if you want to create"
         " a 'group by' option in the search view",
+        states={"ui_valid": [("readonly", True)]},
     )
 
     index_name = fields.Char(compute="_compute_index_name")
 
-    graph_type = fields.Selection(selection=_GRAPH_TYPE_SELECTION)
+    graph_type = fields.Selection(
+        selection=_GRAPH_TYPE_SELECTION,
+        states={"ui_valid": [("readonly", True)]},
+    )
 
     tree_visibility = fields.Selection(
         selection=_TREE_VISIBILITY_SELECTION,
         default="available",
         required=True,
+        states={"ui_valid": [("readonly", True)]},
     )
 
     field_description = fields.Char(
         help="This will be used as the name of the Odoo field, displayed for users",
         required=True,
+        states={"model_valid": [("readonly", True)], "ui_valid": [("readonly", True)]},
     )
 
     ttype = fields.Selection(
@@ -104,6 +113,7 @@ class BiSQLViewField(models.Model):
         " Odoo field that will be created. Keep empty if you don't want to"
         " create a new field. If empty, this field will not be displayed"
         " neither available for search or group by function",
+        states={"model_valid": [("readonly", True)], "ui_valid": [("readonly", True)]},
     )
 
     selection = fields.Text(
@@ -113,24 +123,28 @@ class BiSQLViewField(models.Model):
         " List of options, specified as a Python expression defining a list of"
         " (key, label) pairs. For example:"
         " [('blue','Blue'), ('yellow','Yellow')]",
+        states={"model_valid": [("readonly", True)], "ui_valid": [("readonly", True)]},
     )
 
     many2one_model_id = fields.Many2one(
         comodel_name="ir.model",
         string="Model",
         help="For 'Many2one' Odoo field.\n" " Comodel of the field.",
+        states={"model_valid": [("readonly", True)], "ui_valid": [("readonly", True)]},
     )
 
     group_operator = fields.Selection(
         selection=_GROUP_OPERATOR_SELECTION,
         help="By default, Odoo will sum the values when grouping. If you wish "
         "to alter the behaviour, choose an alternate Group Operator",
+        states={"model_valid": [("readonly", True)], "ui_valid": [("readonly", True)]},
     )
 
     field_context = fields.Char(
         default="{}",
         help="Context value that will be inserted for this field in all the views."
         " Important note : please write a context with single quote.",
+        states={"ui_valid": [("readonly", True)]},
     )
 
     # Constrains Section
@@ -187,6 +201,16 @@ class BiSQLViewField(models.Model):
                 }
             )
         return super().create(vals_list)
+
+    def unlink(self):
+        if self.filtered(lambda x: x.state in ("model_valid", "ui_valid")):
+            raise UserError(
+                _(
+                    "Impossible to delete fields if the view"
+                    " is in the state 'Model Valid' or 'UI Valid'."
+                )
+            )
+        return super().unlink()
 
     # Custom Section
     @api.model

--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -233,12 +233,12 @@ class BiSQLViewField(models.Model):
         if self.tree_visibility == "invisible":
             visibility_text = 'invisible="1"'
         elif self.tree_visibility == "optional_hide":
-            visibility_text = 'option="hide"'
+            visibility_text = 'optional="hide"'
         elif self.tree_visibility == "optional_show":
-            visibility_text = 'option="show"'
+            visibility_text = 'optional="show"'
 
         return (
-            f"""<field name="{self.name}" {visibility_text} """
+            f"""<field name="{self.name}" {visibility_text}"""
             f""" context="{self.field_context}"/>\n"""
         )
 

--- a/bi_sql_editor/tests/test_bi_sql_view.py
+++ b/bi_sql_editor/tests/test_bi_sql_view.py
@@ -33,8 +33,26 @@ class TestBiSqlViewEditor(SingleTransactionCase):
         self.assertEqual(copy_view.state, "draft")
         copy_view.button_validate_sql_expression()
         self.assertEqual(copy_view.state, "sql_valid")
+
+        field_lines = copy_view.bi_sql_view_field_ids
+        self.assertEqual(len(field_lines), 3)
+        field_lines.filtered(lambda x: x.name == "x_company_id").is_index = True
+
         copy_view.button_create_sql_view_and_model()
         self.assertEqual(copy_view.state, "model_valid")
+
+        field_lines.filtered(lambda x: x.name == "x_name").tree_visibility = "invisible"
+        field_lines.filtered(
+            lambda x: x.name == "x_street"
+        ).tree_visibility = "optional_hide"
+        field_lines.filtered(
+            lambda x: x.name == "x_company_id"
+        ).tree_visibility = "optional_show"
+
+        field_lines.filtered(lambda x: x.name == "x_company_id").is_group_by = True
+
+        field_lines.filtered(lambda x: x.name == "x_company_id").graph_type = "row"
+
         copy_view.button_create_ui()
         self.assertEqual(copy_view.state, "ui_valid")
         copy_view.button_update_model_access()

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -111,13 +111,8 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     string="SQL Fields"
                     attrs="{'invisible': [('state', '=', 'draft')]}"
                 >
-                    <field
-                        name="bi_sql_view_field_ids"
-                        nolabel="1"
-                        colspan="4"
-                        attrs="{'readonly': [('state', '!=', 'sql_valid')]}"
-                    >
-                        <tree editable="bottom">
+                    <field name="bi_sql_view_field_ids" nolabel="1" colspan="4">
+                        <tree editable="bottom" create="false">
                             <field name="sequence" widget="handle" />
                             <field name="name" />
                             <field name="sql_type" />
@@ -148,6 +143,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             <field name="is_group_by" optional="hide" />
                             <field name="tree_visibility" optional="hide" />
                             <field name="field_context" optional="hide" />
+                            <field name="state" invisible="1" />
                         </tree>
                     </field>
                 </page>

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -34,14 +34,20 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
                 <button
-                    name="button_set_draft"
+                    name="button_reset_to_sql_valid"
                     type="object"
-                    states="model_valid,ui_valid"
-                    string="Set to Draft"
+                    states="model_valid"
+                    string="Delete SQL Elements"
                     groups="sql_request_abstract.group_sql_request_manager"
-                    confirm="Are you sure you want to set to draft this SQL View. It will delete the materialized view, and all the previous mapping realized with the columns"
+                    confirm="It will delete the materialized view, and all the previous mapping realized with the columns"
                 />
-
+                <button
+                    name="button_reset_to_model_valid"
+                    type="object"
+                    states="ui_valid"
+                    string="Delete UI"
+                    groups="sql_request_abstract.group_sql_request_manager"
+                />
                 <button
                     name="button_create_sql_view_and_model"
                     type="object"
@@ -67,18 +73,18 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     help="This will create Odoo View, Action and Menu"
                 />
                 <button
-                    name="button_refresh_materialized_view"
-                    type="object"
-                    string="Refresh"
-                    help="Refresh Materialized View"
-                    attrs="{'invisible': ['|', ('state', 'in', ('draft', 'sql_valid')), ('is_materialized', '=', False)]}"
-                />
-                <button
                     name="button_open_view"
                     type="object"
                     string="Open View"
                     states="ui_valid"
                     class="oe_highlight"
+                />
+                <button
+                    name="button_refresh_materialized_view"
+                    type="object"
+                    string="Refresh"
+                    help="Refresh Materialized View"
+                    attrs="{'invisible': ['|', ('state', 'in', ('draft', 'sql_valid')), ('is_materialized', '=', False)]}"
                 />
             </xpath>
             <group name="group_main_info" position="inside">

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -104,7 +104,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                         name="cron_id"
                         attrs="{'invisible': ['|', ('state', 'in', ('draft', 'sql_valid')), ('is_materialized', '=', False)]}"
                     />
-                    <field name="option_context_field" />
                 </group>
             </group>
             <page name="page_sql" position="after">
@@ -148,12 +147,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             <field name="graph_type" />
                             <field name="is_group_by" optional="hide" />
                             <field name="tree_visibility" optional="hide" />
-                            <field
-                                name="field_context"
-                                attrs="{
-                                    'column_invisible': [('parent.option_context_field', '=', False)],
-                                }"
-                            />
+                            <field name="field_context" optional="hide" />
                         </tree>
                     </field>
                 </page>

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -118,10 +118,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                         colspan="4"
                         attrs="{'readonly': [('state', '!=', 'sql_valid')]}"
                     >
-                        <tree
-                            editable="bottom"
-                            decoration-info="field_description==False"
-                        >
+                        <tree editable="bottom">
                             <field name="sequence" widget="handle" />
                             <field name="name" />
                             <field name="sql_type" />
@@ -138,9 +135,8 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 name="selection"
                                 attrs="{
                                 'invisible': [('ttype', '!=', 'selection')],
-                                'required': [
-                                    ('field_description', '!=', False),
-                                    ('ttype', '=', 'selection')]}"
+                                'required': [('ttype', '=', 'selection')],
+                            }"
                             />
                             <field
                                 name='group_operator'
@@ -148,29 +144,13 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 attrs="{
                                 'invisible': [('ttype', 'not in', ('float', 'integer'))]}"
                             />
-                            <field
-                                name="is_index"
-                                optional="hide"
-                                attrs="{'invisible': [('field_description', '=', False)]}"
-                            />
-                            <field
-                                name="graph_type"
-                                attrs="{'invisible': [('field_description', '=', False)]}"
-                            />
-                            <field
-                                name="is_group_by"
-                                optional="hide"
-                                attrs="{'invisible': [('field_description', '=', False)]}"
-                            />
-                            <field
-                                name="tree_visibility"
-                                optional="hide"
-                                attrs="{'invisible': [('field_description', '=', False)]}"
-                            />
+                            <field name="is_index" optional="hide" />
+                            <field name="graph_type" />
+                            <field name="is_group_by" optional="hide" />
+                            <field name="tree_visibility" optional="hide" />
                             <field
                                 name="field_context"
                                 attrs="{
-                                    'invisible': [('field_description', '=', False)],
                                     'column_invisible': [('parent.option_context_field', '=', False)],
                                 }"
                             />


### PR DESCRIPTION
* [IMP] Make installation idem potens
* [REF] simplify tests
* [FIX] allow to pass default values in copy() function
* [FIX] do not allow to create model (and sql views) if related model are not set on many2one fields. It prevents the error 'AttributeError: '_unknown' object has no attribute 'id''
* [FIX] Use correct key word 'optional'. (and not 'option') in tree view
* [IMP]  allow to reset to the previous state, and not only into 'draft' state
* [REF]  simplification : Remove conditional display related to field_description, as this field is required and so, allways defined
* [REM] option_context_field field, as it is now possible to implement that feature with optional='hide' on the field list view
* [IMP] Allow to change fields settings if state is 'Model Valid'. Avoid to reset to draft and to have to recreate view that can take a while, if the view is materialized
* [IMP] Improve code coverage, adding various settings on field items



