### PR TITLE
16.0][FIX] report_label fix a security issue

### DIFF
--- a/report_label/wizards/report_label_wizard.py
+++ b/report_label/wizards/report_label_wizard.py
@@ -61,9 +61,9 @@ class ReportLabelWizard(models.TransientModel):
         self.ensure_one()
         return {
             "label_format": self.label_paperformat_id.read()[0],
-            "label_template": self.label_template_view_id.key,
+            "label_template": self.label_template_view_id.sudo().key,
             "offset": self.offset,
-            "res_model": self.model_id.model,
+            "res_model": self.model_id.sudo().model,
             "lines": [
                 {
                     "res_id": line.res_id,

--- a/report_label/wizards/report_label_wizard_line.py
+++ b/report_label/wizards/report_label_wizard_line.py
@@ -22,7 +22,7 @@ class ReportLabelWizardLine(models.TransientModel):
     def _compute_res_name(self):
         wizard = self.mapped("wizard_id")
         wizard.ensure_one()
-        res_model = wizard.model_id.model
+        res_model = wizard.model_id.sudo().model
         res_ids = self.mapped("res_id")
         names_map = dict(self.env[res_model].browse(res_ids).name_get())
         for rec in self:


### PR DESCRIPTION
Odoo V16 does not allow 'regular' users (ie users with no Admin/Access Right group) to acces to ir.model at all and ir.ui.view either (only for group Admin/Settings for the latter), therefore i added some sudoes to allow users with no such right to be able to actually print labels.
Did not find a more elegant solution.