### PR TITLE
[16.0][FIX] report_async: replaced parent menu

### DIFF
--- a/report_async/__manifest__.py
+++ b/report_async/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/reporting-engine",
     "category": "Generic Modules",
-    "depends": ["queue_job"],
+    "depends": ["queue_job", "spreadsheet_dashboard"],
     "data": [
         "security/ir.model.access.csv",
         "security/ir_rule.xml",

--- a/report_async/views/report_async.xml
+++ b/report_async/views/report_async.xml
@@ -155,9 +155,9 @@
     </record>
     <menuitem
         id="menu_report_async"
-        parent="base.menu_board_root"
+        parent="spreadsheet_dashboard.spreadsheet_dashboard_menu_root"
         action="action_report_async"
-        sequence="10"
+        sequence="20"
     />
     <record id="action_view_files" model="ir.actions.act_window">
         <field name="name">Report Files</field>


### PR DESCRIPTION
Changed the parent from Report Center menu item since odoo is using now spreadsheet_dashboard_menu_root instead of menu_board_root