### PR TITLE
[FIX] report_xlsx: keep sudo

### DIFF
--- a/report_xlsx/models/ir_report.py
+++ b/report_xlsx/models/ir_report.py
@@ -21,11 +21,11 @@ class ReportAction(models.Model):
         report_sudo = self._get_report(report_ref)
         report_model_name = "report.%s" % report_sudo.report_name
         report_model = self.env[report_model_name]
-        ret = (
-            report_model.with_context(active_model=report_sudo.model)
-            .sudo(False)
-            .create_xlsx_report(docids, data)  # noqa
-        )
+        ret = report_model.with_context(
+            active_model=report_sudo.model
+        ).create_xlsx_report(
+            docids, data
+        )  # noqa
         if ret and isinstance(ret, (tuple, list)):  # data, "xlsx"
             report_sudo.save_xlsx_report_attachment(docids, ret[0])
         return ret


### PR DESCRIPTION
Explicit `sudo(False)` is not needed anymore, as Odoo core also removed it from the other QWeb reports (see https://github.com/odoo/odoo/commit/ffc525419a71aeb05ede6b59dda9e62286a5e66e)

This change was made for 14.0 in https://github.com/OCA/reporting-engine/pull/587 (see related issue https://github.com/OCA/reporting-engine/issues/586). Odoo server was modified for 16.0 in https://github.com/odoo/odoo/commit/ffc525419a71aeb05ede6b59dda9e62286a5e66e removing all `sudo(False)` from other the other QWeb render processes, so here it is not needed anymore.