### PR TITLE
[FIX] base_comment_template: Search by model_ids.model

### DIFF
--- a/base_comment_template/README.rst
+++ b/base_comment_template/README.rst
@@ -169,6 +169,10 @@ Contributors
 
   * Achraf Mhadhbi <machraf@bloopark.de>
 
+*  `Aion Tech <https://aiontech.company/>`__:
+
+  *  Simone Rubino <simone.rubino@aion-tech.it>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/base_comment_template/readme/CONTRIBUTORS.rst
+++ b/base_comment_template/readme/CONTRIBUTORS.rst
@@ -28,3 +28,7 @@
 * `Bloopark systems <https://www.bloopark.de/>`_:
 
   * Achraf Mhadhbi <machraf@bloopark.de>
+
+*  `Aion Tech <https://aiontech.company/>`__:
+
+  *  Simone Rubino <simone.rubino@aion-tech.it>

--- a/base_comment_template/static/description/index.html
+++ b/base_comment_template/static/description/index.html
@@ -510,7 +510,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Achraf Mhadhbi &lt;<a class="reference external" href="mailto:machraf&#64;bloopark.de">machraf&#64;bloopark.de</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:</li>
 </ul>
+<blockquote>
+<ul class="simple">
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
+</ul>
+</blockquote>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>

--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -1,5 +1,6 @@
 # Copyright 2020 NextERP Romania SRL
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import Command
 from odoo.exceptions import ValidationError
@@ -184,3 +185,28 @@ class TestCommentTemplate(common.TransactionCase):
         self.assertTrue(
             "base_comment_template_ids" in self.env["res.partner"]._commercial_fields()
         )
+
+    def test_search_model_ids_model(self):
+        """Searching by "model_ids.model"
+        finds the comments matching the search criteria."""
+        # Arrange
+        comment_template_model = self.env["base.comment.template"]
+        user_ir_model = self.user_obj
+        user_model_name = user_ir_model.model
+        user_comments_by_model_ids = comment_template_model.search(
+            [
+                ("model_ids", "=", user_model_name),
+            ]
+        )
+        # pre-condition
+        self.assertTrue(user_comments_by_model_ids)
+
+        # Act
+        user_comments_by_models_path = comment_template_model.search(
+            [
+                ("model_ids.model", "=", user_model_name),
+            ]
+        )
+
+        # Assert
+        self.assertEqual(user_comments_by_model_ids, user_comments_by_models_path)


### PR DESCRIPTION
**Steps**:

1. Search comment templates using the domain [("model_ids.model", "=", "your_model")]

**Actual behavior**:
Nothing is found

**Expected behavior**:
Comments for model **your_model** are found