### PR TITLE
[12.0][FIX] report_wkhtmltopdf_param: remove deprecated parameter

### DIFF
--- a/report_wkhtmltopdf_param/__manifest__.py
+++ b/report_wkhtmltopdf_param/__manifest__.py
@@ -25,5 +25,4 @@
     "installable": True,
     "auto_install": False,
     "application": False,
-    "active": False,
 }


### PR DESCRIPTION
I don't know how the module was tested before getting merged 🤔