### PR TITLE
[11.0][FIX] report_wkhtmltopdf_param: activate it (backport)

### DIFF
--- a/report_wkhtmltopdf_param/__manifest__.py
+++ b/report_wkhtmltopdf_param/__manifest__.py
@@ -25,5 +25,4 @@
     "installable": True,
     "auto_install": False,
     "application": False,
-    "active": False,
 }


### PR DESCRIPTION
Backport of https://github.com/OCA/reporting-engine/pull/870.