### PR TITLE
[16] sql_export : Add last_run datetime field

### DIFF
--- a/sql_export/models/sql_export.py
+++ b/sql_export/models/sql_export.py
@@ -19,6 +19,7 @@ class SqlExport(models.Model):
 
     use_properties = fields.Boolean(compute="_compute_use_properties")
     query_properties_definition = fields.PropertiesDefinition("Query Properties")
+    last_run = fields.Datetime()
 
     encoding = fields.Selection(
         [

--- a/sql_export/models/sql_export.py
+++ b/sql_export/models/sql_export.py
@@ -19,7 +19,10 @@ class SqlExport(models.Model):
 
     use_properties = fields.Boolean(compute="_compute_use_properties")
     query_properties_definition = fields.PropertiesDefinition("Query Properties")
-    last_run = fields.Datetime()
+    last_execution_date = fields.Datetime(readonly=True)
+    last_execution_uid = fields.Many2one(
+        "res.users", string="Last execution User", readonly=True
+    )
 
     encoding = fields.Selection(
         [

--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -72,7 +72,8 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <field name="state" position="after">
-                <field name="last_run" />
+                <field name="last_execution_date" optional="hide" />
+                <field name="last_execution_uid" optional="hide" />
                 <button
                     name="export_sql_query"
                     string="Execute Query"

--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -72,6 +72,7 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <field name="state" position="after">
+                <field name="last_run" />
                 <button
                     name="export_sql_query"
                     string="Execute Query"

--- a/sql_export/wizard/wizard_file.py
+++ b/sql_export/wizard/wizard_file.py
@@ -63,7 +63,21 @@ class SqlFileWizard(models.TransientModel):
                 % {"name": sql_export.name, "date": date, "extension": extension},
             }
         )
-        sql_export.write({"last_run": fields.Datetime.now()})
+        # Bypass ORM to avoid changing the write_date/uid from sql query on a simple
+        # execution. This also avoid error if user has no update right on the
+        # sql.export object.
+        self.env.cr.execute(
+            """
+            UPDATE sql_export
+            SET last_execution_date = %s, last_execution_uid = %s
+            WHERE id = %s
+        """,
+            (
+                fields.Datetime.to_string(fields.Datetime.now()),
+                self.env.user.id,
+                sql_export.id,
+            ),
+        )
         action = {
             "name": "SQL Export",
             "type": "ir.actions.act_url",

--- a/sql_export/wizard/wizard_file.py
+++ b/sql_export/wizard/wizard_file.py
@@ -63,6 +63,7 @@ class SqlFileWizard(models.TransientModel):
                 % {"name": sql_export.name, "date": date, "extension": extension},
             }
         )
+        sql_export.write({"last_run": fields.Datetime.now()})
         action = {
             "name": "SQL Export",
             "type": "ir.actions.act_url",


### PR DESCRIPTION
Very small addition, which can become quite usefull when there are hundreds of queries and some may not be used anymore.
In case of migration for instance, it may allow to priorize which should be migrated or not, etc...

@legalsylvain 