### PR TITLE
[FIX] bi_sql_editor : prevent to raise an error when creating a cron for a materialized view,

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from psycopg2 import ProgrammingError
 
 from odoo import _, api, fields, models, SUPERUSER_ID
@@ -402,7 +402,7 @@ class BiSQLView(models.Model):
             'numbercall': -1,
             'interval_number': 1,
             'interval_type': 'days',
-            'nextcall': datetime(now.year, now.month, now.day+1),
+            "nextcall": now + timedelta(days=1),
             'active': True,
         }
 


### PR DESCRIPTION
 if it is the last day of the month.

Backport of recent improvment.

when the current date is May, 31 2024, the current prepare function will fail, when trying to cast a date with the value 2024-05-32.

 
