### PR TITLE
[16.0][FW][IMP]bi_sql_editor: add parent menu as an editable parameter when creating UI elements

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -126,7 +126,31 @@ class BiSQLView(models.Model):
     model_id = fields.Many2one(
         string="Odoo Model", comodel_name="ir.model", readonly=True
     )
+    # UI related fields
+    # 1. Editable fields, which can be set by the user (optional) before
+    # creating the UI elements
 
+    @api.model
+    def _default_parent_menu_id(self):
+        return self.env.ref("bi_sql_editor.menu_bi_sql_editor")
+
+    parent_menu_id = fields.Many2one(
+        string="Parent Odoo Menu",
+        comodel_name="ir.ui.menu",
+        required=True,
+        readonly=True,
+        default=lambda self: self._default_parent_menu_id(),
+        states={
+            "draft": [("readonly", False)],
+            "sql_valid": [("readonly", False)],
+            "model_valid": [("readonly", False)],
+        },
+        help="By assigning a value to this field before manually creating the "
+        "UI, you're overwriting the parent menu on which the menu related to "
+        "the SQL report will be created.",
+    )
+
+    # 2. Readonly fields, non editable by the user
     tree_view_id = fields.Many2one(
         string="Odoo Tree View", comodel_name="ir.ui.view", readonly=True
     )
@@ -515,7 +539,7 @@ class BiSQLView(models.Model):
         self.ensure_one()
         return {
             "name": self.name,
-            "parent_id": self.env.ref("bi_sql_editor.menu_bi_sql_editor").id,
+            "parent_id": self.parent_menu_id.id,
             "action": "ir.actions.act_window,%s" % self.action_id.id,
             "sequence": self.sequence,
         }

--- a/bi_sql_editor/readme/CONFIGURE.rst
+++ b/bi_sql_editor/readme/CONFIGURE.rst
@@ -38,5 +38,10 @@ to make reporting depending on the current companies of the user.
   .. figure:: ../static/description/04_materialized_view_setting.png
      :width: 800 px
 
+* Before applying the final step, you will need to add a specific Parent Menu to
+  use when creating the UI Menu for the report. By default, it will be set with
+  the `SQL Views` menu, which can be changed before creating the UI elements in
+  order to have the report accessible from a different place within Odoo.
+
 * Finally, click on 'Create UI', to create new menu, action, graph view and
   search view.

--- a/bi_sql_editor/readme/CONTRIBUTORS.rst
+++ b/bi_sql_editor/readme/CONTRIBUTORS.rst
@@ -1,6 +1,7 @@
 * Sylvain LE GAL (https://twitter.com/legalsylvain)
 * Richard deMeester, WilldooIT (http://www.willdooit.com/)
 * David James, WilldooIT (http://www.willdooit.com/)
+* Guillem Casassas <guillem.casassas@forgeflow.com>
 
 * This module is highly inspired by the work of
     * Onestein: (http://www.onestein.nl/)

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -196,12 +196,17 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             />
                                 </group>
                                 <group string="User Interface">
-                                    <field name="tree_view_id" />
-                                    <field name="graph_view_id" />
-                                    <field name="pivot_view_id" />
-                                    <field name="search_view_id" />
-                                    <field name="action_id" />
-                                    <field name="menu_id" />
+                                    <group string="UI Parameters">
+                                        <field name="parent_menu_id" />
+                                    </group>
+                                    <group string="UI Instances">
+                                        <field name="tree_view_id" />
+                                        <field name="graph_view_id" />
+                                        <field name="pivot_view_id" />
+                                        <field name="search_view_id" />
+                                        <field name="action_id" />
+                                        <field name="menu_id" />
+                                    </group>
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
When creating the UI for the SQL view, it is now possible to set a specific Parent Menu which will be used when creating the UI Menu for the report itself. The default value will be the `SQL Reports` menu. Also, added the explanation on the `CONFIGURE.rst` file to have the description updated.

FW of https://github.com/OCA/reporting-engine/pull/891

cc @ForgeFlow