### PR TITLE
[17.0][FW][IMP]bi_sql_editor: add parent menu as an editable parameter when creating UI elements

### DIFF
--- a/bi_sql_editor/README.rst
+++ b/bi_sql_editor/README.rst
@@ -117,6 +117,12 @@ to make reporting depending on the current companies of the user.
 
    |image4|
 
+-  Before applying the final step, you will need to add a specific
+   Parent Menu to use when creating the UI Menu for the report. By
+   default, it will be set with the ``SQL Views`` menu, which can be
+   changed before creating the UI elements in order to have the report
+   accessible from a different place within Odoo.
+
 -  Finally, click on 'Create UI', to create new menu, action, graph view
    and search view.
 
@@ -167,6 +173,8 @@ Contributors
 -  Richard deMeester, WilldooIT (http://www.willdooit.com/)
 
 -  David James, WilldooIT (http://www.willdooit.com/)
+
+-  Guillem Casassas guillem.casassas@forgeflow.com
 
 -  This module is highly inspired by the work of
 

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -114,7 +114,25 @@ class BiSQLView(models.Model):
     model_id = fields.Many2one(
         string="Odoo Model", comodel_name="ir.model", readonly=True
     )
+    # UI related fields
+    # 1. Editable fields, which can be set by the user (optional) before
+    # creating the UI elements
 
+    @api.model
+    def _default_parent_menu_id(self):
+        return self.env.ref("bi_sql_editor.menu_bi_sql_editor")
+
+    parent_menu_id = fields.Many2one(
+        string="Parent Odoo Menu",
+        comodel_name="ir.ui.menu",
+        required=True,
+        default=lambda self: self._default_parent_menu_id(),
+        help="By assigning a value to this field before manually creating the "
+        "UI, you're overwriting the parent menu on which the menu related to "
+        "the SQL report will be created.",
+    )
+
+    # 2. Readonly fields, non editable by the user
     tree_view_id = fields.Many2one(
         string="Odoo Tree View", comodel_name="ir.ui.view", readonly=True
     )
@@ -491,7 +509,7 @@ class BiSQLView(models.Model):
         self.ensure_one()
         return {
             "name": self.name,
-            "parent_id": self.env.ref("bi_sql_editor.menu_bi_sql_editor").id,
+            "parent_id": self.parent_menu_id.id,
             "action": "ir.actions.act_window,%s" % self.action_id.id,
             "sequence": self.sequence,
         }

--- a/bi_sql_editor/readme/CONFIGURE.md
+++ b/bi_sql_editor/readme/CONFIGURE.md
@@ -34,5 +34,10 @@ to make reporting depending on the current companies of the user.
 
   ![](../static/description/04_materialized_view_setting.png)
 
+- Before applying the final step, you will need to add a specific Parent Menu to
+  use when creating the UI Menu for the report. By default, it will be set with
+  the `SQL Views` menu, which can be changed before creating the UI elements in
+  order to have the report accessible from a different place within Odoo.
+
 - Finally, click on 'Create UI', to create new menu, action, graph view
   and search view.

--- a/bi_sql_editor/readme/CONTRIBUTORS.md
+++ b/bi_sql_editor/readme/CONTRIBUTORS.md
@@ -4,7 +4,9 @@
 
 - David James, WilldooIT (<http://www.willdooit.com/>)
 
-- This module is highly inspired by the work of  
+- Guillem Casassas <guillem.casassas@forgeflow.com>
+
+- This module is highly inspired by the work of
   - Onestein: (<http://www.onestein.nl/>) Module:
     OCA/server-tools/bi_view_editor. Link:
     <https://github.com/OCA/reporting-engine/tree/9.0/bi_view_editor>

--- a/bi_sql_editor/static/description/index.html
+++ b/bi_sql_editor/static/description/index.html
@@ -453,6 +453,12 @@ the frequency of the refresh.</li>
 </blockquote>
 <p><img alt="image4" src="https://raw.githubusercontent.com/OCA/reporting-engine/17.0/bi_sql_editor/static/description/04_materialized_view_setting.png" /></p>
 </li>
+<li><p class="first">Before applying the final step, you will need to add a specific
+Parent Menu to use when creating the UI Menu for the report. By
+default, it will be set with the <tt class="docutils literal">SQL Views</tt> menu, which can be
+changed before creating the UI elements in order to have the report
+accessible from a different place within Odoo.</p>
+</li>
 <li><p class="first">Finally, click on ‘Create UI’, to create new menu, action, graph view
 and search view.</p>
 </li>
@@ -496,6 +502,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Sylvain LE GAL (<a class="reference external" href="https://twitter.com/legalsylvain">https://twitter.com/legalsylvain</a>)</li>
 <li>Richard deMeester, WilldooIT (<a class="reference external" href="http://www.willdooit.com/">http://www.willdooit.com/</a>)</li>
 <li>David James, WilldooIT (<a class="reference external" href="http://www.willdooit.com/">http://www.willdooit.com/</a>)</li>
+<li>Guillem Casassas <a class="reference external" href="mailto:guillem.casassas&#64;forgeflow.com">guillem.casassas&#64;forgeflow.com</a></li>
 <li>This module is highly inspired by the work of<ul>
 <li>Onestein: (<a class="reference external" href="http://www.onestein.nl/">http://www.onestein.nl/</a>) Module:
 OCA/server-tools/bi_view_editor. Link:

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -214,12 +214,20 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             />
                                 </group>
                                 <group string="User Interface">
-                                    <field name="tree_view_id" />
-                                    <field name="graph_view_id" />
-                                    <field name="pivot_view_id" />
-                                    <field name="search_view_id" />
-                                    <field name="action_id" />
-                                    <field name="menu_id" />
+                                    <group string="UI Parameters">
+                                        <field
+                                    name="parent_menu_id"
+                                    readonly="state == 'ui_valid'"
+                                />
+                                    </group>
+                                    <group string="UI Instances">
+                                        <field name="tree_view_id" />
+                                        <field name="graph_view_id" />
+                                        <field name="pivot_view_id" />
+                                        <field name="search_view_id" />
+                                        <field name="action_id" />
+                                        <field name="menu_id" />
+                                    </group>
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
When creating the UI for the SQL view, it is now possible to set a specific Parent Menu which will be used when creating the UI Menu for the report itself. The default value will be the `SQL Reports` menu. Also, added the explanation on the `CONFIGURE.rst` file to have the description updated.

FW of https://github.com/OCA/reporting-engine/pull/891

cc @ForgeFlow