### PR TITLE
[17.0][IMP]bi_sql_editor: scheduled action periodicity settings

### DIFF
--- a/bi_sql_editor/README.rst
+++ b/bi_sql_editor/README.rst
@@ -117,11 +117,16 @@ to make reporting depending on the current companies of the user.
 
    |image4|
 
--  Before applying the final step, you will need to add a specific
-   Parent Menu to use when creating the UI Menu for the report. By
-   default, it will be set with the ``SQL Views`` menu, which can be
-   changed before creating the UI elements in order to have the report
-   accessible from a different place within Odoo.
+-  Before creating the UI elements: you can modify two specific settings
+   based on your needs:
+
+   -  **Parent Menu**: Apply a Parent Menu to use for when creating the
+      UI elements. By default, it will be set with the ``SQL Views``
+      menu, which can be changed in order to have the report accessible
+      from a different place within Odoo.
+   -  **Scheduled Action periodicity**: By going to the Settings page,
+      you can customize the frequency for which you want to run the
+      Scheduled Action that will refresh the Materialized view.
 
 -  Finally, click on 'Create UI', to create new menu, action, graph view
    and search view.

--- a/bi_sql_editor/readme/CONFIGURE.md
+++ b/bi_sql_editor/readme/CONFIGURE.md
@@ -34,10 +34,15 @@ to make reporting depending on the current companies of the user.
 
   ![](../static/description/04_materialized_view_setting.png)
 
-- Before applying the final step, you will need to add a specific Parent Menu to
-  use when creating the UI Menu for the report. By default, it will be set with
-  the `SQL Views` menu, which can be changed before creating the UI elements in
-  order to have the report accessible from a different place within Odoo.
+- Before creating the UI elements: you can modify two specific settings based
+  on your needs:
+  - **Parent Menu**: Apply a Parent Menu to use for when creating the UI
+  elements. By default, it will be set with the `SQL Views` menu, which can be
+  changed in order to have the report accessible from a different place within
+  Odoo.
+  - **Scheduled Action periodicity**: By going to the Settings page, you can
+  customize the frequency for which you want to run the Scheduled Action that
+  will refresh the Materialized view.
 
 - Finally, click on 'Create UI', to create new menu, action, graph view
   and search view.

--- a/bi_sql_editor/static/description/index.html
+++ b/bi_sql_editor/static/description/index.html
@@ -453,11 +453,17 @@ the frequency of the refresh.</li>
 </blockquote>
 <p><img alt="image4" src="https://raw.githubusercontent.com/OCA/reporting-engine/17.0/bi_sql_editor/static/description/04_materialized_view_setting.png" /></p>
 </li>
-<li><p class="first">Before applying the final step, you will need to add a specific
-Parent Menu to use when creating the UI Menu for the report. By
-default, it will be set with the <tt class="docutils literal">SQL Views</tt> menu, which can be
-changed before creating the UI elements in order to have the report
-accessible from a different place within Odoo.</p>
+<li><p class="first">Before creating the UI elements: you can modify two specific settings
+based on your needs:</p>
+<ul class="simple">
+<li><strong>Parent Menu</strong>: Apply a Parent Menu to use for when creating the
+UI elements. By default, it will be set with the <tt class="docutils literal">SQL Views</tt>
+menu, which can be changed in order to have the report accessible
+from a different place within Odoo.</li>
+<li><strong>Scheduled Action periodicity</strong>: By going to the Settings page,
+you can customize the frequency for which you want to run the
+Scheduled Action that will refresh the Materialized view.</li>
+</ul>
 </li>
 <li><p class="first">Finally, click on ‘Create UI’, to create new menu, action, graph view
 and search view.</p>

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -185,53 +185,61 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             </field>
 
             <page name="page_security" position="after">
-                        <page string="Action Settings">
-                            <group string="Computed Context">
-                                <field
-                            name="computed_action_context"
-                            nolabel="1"
-                            colspan="2"
-                        />
-                            </group>
-                            <group string="Custom Context">
-                                <field
-                            name="action_context"
-                            readonly="state not in ('draft', 'sql_valid', 'model_valid')"
-                            nolabel="1"
-                            colspan="2"
-                            widget="ace"
-                            options="{'mode': 'python'}"
-                        />
-                            </group>
-                        </page>
-                        <page string="Extras Information">
-                            <group>
-                                <group string="Model">
-                                    <field name="model_name" />
-                                    <field
-                                name="model_id"
-                                invisible="state == 'draft'"
+                <page string="Settings" name="page_settings">
+                    <group name="action_settings" string="Action Settings">
+                        <group string="Computed Context">
+                            <field
+                                name="computed_action_context"
+                                nolabel="1"
+                                colspan="2"
                             />
-                                </group>
-                                <group string="User Interface">
-                                    <group string="UI Parameters">
-                                        <field
+                        </group>
+                        <group string="Custom Context">
+                            <field
+                                name="action_context"
+                                readonly="state not in ('draft', 'sql_valid', 'model_valid')"
+                                nolabel="1"
+                                colspan="2"
+                                widget="ace"
+                                options="{'mode': 'python'}"
+                            />
+                        </group>
+                    </group>
+                    <group name="ir_cron_settings" string="Scheduled Action settings">
+                        <field
+                            name="cron_interval_number"
+                            readonly="state == 'ui_valid'"
+                        />
+                        <field
+                            name="cron_interval_type"
+                            readonly="state == 'ui_valid'"
+                        />
+                    </group>
+                </page>
+                <page string="Extras Information">
+                    <group>
+                        <group string="Model">
+                            <field name="model_name" />
+                            <field name="model_id" invisible="state == 'draft'" />
+                        </group>
+                        <group string="User Interface">
+                            <group string="UI Parameters">
+                                <field
                                     name="parent_menu_id"
                                     readonly="state == 'ui_valid'"
                                 />
-                                    </group>
-                                    <group string="UI Instances">
-                                        <field name="tree_view_id" />
-                                        <field name="graph_view_id" />
-                                        <field name="pivot_view_id" />
-                                        <field name="search_view_id" />
-                                        <field name="action_id" />
-                                        <field name="menu_id" />
-                                    </group>
-                                </group>
                             </group>
-                        </page>
-
+                            <group string="UI Instances">
+                                <field name="tree_view_id" />
+                                <field name="graph_view_id" />
+                                <field name="pivot_view_id" />
+                                <field name="search_view_id" />
+                                <field name="action_id" />
+                                <field name="menu_id" />
+                            </group>
+                        </group>
+                    </group>
+                </page>
             </page>
 
             <field name="group_ids" position="attributes">


### PR DESCRIPTION
refactor `Action Settings` page to have all settings, renamed to `Settings`. Added the settings to be able to customize the periodicity of the Scheduled Action that will refresh the Materialized view.

cc @ForgeFlow