### PR TITLE
[12.0][IMP] report_async: change job_ids to One2many with queue.job

### DIFF
--- a/report_async/migrations/12.0.1.2.0/post-migration.py
+++ b/report_async/migrations/12.0.1.2.0/post-migration.py
@@ -1,0 +1,19 @@
+from openupgradelib import openupgrade
+
+
+def populate_report_async_id(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE queue_job qj
+        SET report_async_id = ra.id
+        FROM report_async ra
+        WHERE qj.func_string LIKE '%report.async(' || ra.id || ',%'
+          AND qj.user_id = ra.create_uid
+        """
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    populate_report_async_id(env)

--- a/report_async/models/__init__.py
+++ b/report_async/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import report_async
 from . import ir_report
+from . import queue_job

--- a/report_async/models/queue_job.py
+++ b/report_async/models/queue_job.py
@@ -1,0 +1,12 @@
+from odoo import models, fields
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    report_async_id = fields.Many2one(
+        comodel_name='report.async',
+        string='Report Async',
+        index=True,
+        ondelete='cascade',
+    )


### PR DESCRIPTION
Due to performance considerations, the string-based search has been replaced. We have optimized this by directly linking rec.job_ids to queue.job records using a direct relationship defined as a One2many field in the report.async model.

cc @ForgeFlow