### PR TITLE
[16.0] FIX] report_py3o: fix error in py3o_context_parser

### DIFF
--- a/report_py3o/models/_py3o_parser_context.py
+++ b/report_py3o/models/_py3o_parser_context.py
@@ -136,4 +136,4 @@ class Py3oParserContext(object):
                 no_break_space=True,
             )
 
-        return self._format_date(self._env, value)
+        return self._format_date(value)


### PR DESCRIPTION
Supersedes #835 

The definition of the _format_date function is `def _format_date(self, value, lang_code=False, date_format=False):` no env must be passed when calling it.