### PR TITLE
[16.0][FIX] report_substitute: adding change of main method

### DIFF
--- a/report_substitute/wizards/mail_compose_message.py
+++ b/report_substitute/wizards/mail_compose_message.py
@@ -9,7 +9,7 @@ class MailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
 
     @api.onchange("template_id")
-    def onchange_template_id_wrapper(self):
+    def _onchange_template_id_wrapper(self):
         if self.template_id:
             report_template = self.template_id.report_template
             active_ids = []


### PR DESCRIPTION
The main method that belongs to odoo changed in the migration and was not taken into account when migrating, however the name had been changed in the super methods. This never allowed me to enter the method and there were errors when rendering templates with reports that had substitution rules.