### PR TITLE
[16.0][FIX] report_py3o: change display_address() to _display_address()

### DIFF
--- a/report_py3o/models/_py3o_parser_context.py
+++ b/report_py3o/models/_py3o_parser_context.py
@@ -27,7 +27,7 @@ def format_multiline_value(value):
 
 
 def display_address(address_record, without_company=False):
-    return address_record.display_address(without_company=without_company)
+    return address_record._display_address(without_company=without_company)
 
 
 class Py3oParserContext(object):


### PR DESCRIPTION
In `res.partner` there is no `display_address()` but instead `_display_address()`