### PR TITLE
[FIX] report_substitute: handle reports without xml_id

### DIFF
--- a/report_substitute/models/ir_actions_report.py
+++ b/report_substitute/models/ir_actions_report.py
@@ -45,7 +45,7 @@ class IrActionReport(models.Model):
                 substitution_report = action_report._get_substitution_report(
                     action_report.model, active_ids
                 )
-            action.update(self._for_xml_id(action_report.xml_id))
+            action.update(action_report.read()[0])
 
         return action
 


### PR DESCRIPTION
The change replaces self._for_xml_id(action_report.xml_id) with action_report.read()[0] to avoid errors when reports do not have an xml_id, such as when they are created via the interface.