### PR TITLE
[IMP] add _is_report_type_signable to allow signing other types of pdf

### DIFF
--- a/report_qweb_signer/models/ir_actions_report.py
+++ b/report_qweb_signer/models/ir_actions_report.py
@@ -34,9 +34,13 @@ def _normalize_filepath(path):
 class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
 
+    def _is_report_type_signable(self):
+        self.ensure_one()
+        return self.report_type == "qweb-pdf"
+
     def _certificate_get(self, report, res_ids):
         """Obtain the proper certificate for the report and the conditions."""
-        if report.report_type != "qweb-pdf":
+        if not report._is_report_type_signable():
             return False
         company_id = self.env.company.id
         if res_ids:


### PR DESCRIPTION
Using the _is_report_type_signable method to determine signable report types allow to reuse the signing code for other types of pdf (py3o for example)