### PR TITLE
[16.0][IMP] report_qweb_pdf_watermark: support pypdf >= 2.0

### DIFF
--- a/report_qweb_pdf_watermark/README.rst
+++ b/report_qweb_pdf_watermark/README.rst
@@ -146,6 +146,14 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-hbrunn| image:: https://github.com/hbrunn.png?size=40px
+    :target: https://github.com/hbrunn
+    :alt: hbrunn
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-hbrunn| 
+
 This module is part of the `OCA/reporting-engine <https://github.com/OCA/reporting-engine/tree/16.0/report_qweb_pdf_watermark>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/report_qweb_pdf_watermark/__manifest__.py
+++ b/report_qweb_pdf_watermark/__manifest__.py
@@ -10,6 +10,7 @@
     "summary": "Add watermarks to your QWEB PDF reports",
     "website": "https://github.com/OCA/reporting-engine",
     "depends": ["web"],
+    "maintainers": ["hbrunn"],
     "data": [
         "demo/report.xml",
         "views/ir_actions_report_xml.xml",

--- a/report_qweb_pdf_watermark/models/report.py
+++ b/report_qweb_pdf_watermark/models/report.py
@@ -19,8 +19,16 @@ except ImportError:
     logger.error("ImportError: The PdfImagePlugin could not be imported")
 
 try:
-    from PyPDF2 import PdfFileReader, PdfFileWriter  # pylint: disable=W0404
-    from PyPDF2.utils import PdfReadError  # pylint: disable=W0404
+
+    try:
+        from PyPDF2 import PdfReader, PdfWriter  # pylint: disable=W0404
+        from PyPDF2.errors import PdfReadError  # pypdf >= 2.0
+    except ImportError:
+        from PyPDF2 import (  # pylint: disable=W0404
+            PdfFileReader as PdfReader,
+            PdfFileWriter as PdfWriter,
+        )
+        from PyPDF2.utils import PdfReadError  # pypdf < 2.0
 except ImportError:
     logger.debug("Can not import PyPDF2")
 
@@ -108,11 +116,11 @@ class Report(models.Model):
         if not watermark:
             return result
 
-        pdf = PdfFileWriter()
+        pdf = PdfWriter()
         pdf_watermark = None
         try:
-            pdf_watermark = PdfFileReader(BytesIO(watermark))
-        except PdfReadError:
+            pdf_watermark = PdfReader(BytesIO(watermark))
+        except (UnicodeDecodeError, PdfReadError):
             # let's see if we can convert this with pillow
             try:
                 Image.init()
@@ -124,7 +132,7 @@ class Report(models.Model):
                 if isinstance(resolution, tuple):
                     resolution = resolution[0]
                 image.save(pdf_buffer, "pdf", resolution=resolution)
-                pdf_watermark = PdfFileReader(pdf_buffer)
+                pdf_watermark = PdfReader(pdf_buffer)
             except Exception as e:
                 logger.exception("Failed to load watermark", e)
 
@@ -135,12 +143,16 @@ class Report(models.Model):
         if not self.pdf_has_usable_pages(pdf_watermark.numPages):
             return result
 
-        for page in PdfFileReader(BytesIO(result)).pages:
+        for page in PdfReader(BytesIO(result)).pages:
             watermark_page = pdf.addBlankPage(
                 page.mediaBox.getWidth(), page.mediaBox.getHeight()
             )
-            watermark_page.mergePage(pdf_watermark.getPage(0))
-            watermark_page.mergePage(page)
+            # merge_page is >= 2.0, mergePage < 2.0
+            merge_page = (
+                getattr(watermark_page, "merge_page", None) or watermark_page.mergePage
+            )
+            merge_page(pdf_watermark.getPage(0))
+            merge_page(page)
 
         pdf_content = BytesIO()
         pdf.write(pdf_content)

--- a/report_qweb_pdf_watermark/static/description/index.html
+++ b/report_qweb_pdf_watermark/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -498,6 +497,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/hbrunn"><img alt="hbrunn" src="https://github.com/hbrunn.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/reporting-engine/tree/16.0/report_qweb_pdf_watermark">OCA/reporting-engine</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
see https://pypdf2.readthedocs.io/en/3.0.0/user/migration-1-to-2.html