### PR TITLE
[14.0] report_xlsx: Fix currency format

### DIFF
--- a/report_xlsx/report/report_abstract_xlsx.py
+++ b/report_xlsx/report/report_abstract_xlsx.py
@@ -92,11 +92,9 @@ class ReportXlsxAbstract(models.AbstractModel):
         return self.env[self.env.context.get("active_model")].browse(ids)
 
     def _report_xlsx_currency_format(self, currency):
-        """Get the format to be used in cells (symbol included).
+        """Get currency format to be used in cells.
         Used in account_financial_report addon"""
-        s_before = currency.symbol if currency.position == "before" else ""
-        s_after = " %s" % currency.symbol if currency.position == "after" else ""
-        return f"{f'{s_before}'}#,##0.{'0' * currency.decimal_places}{f'{s_after}'}"
+        return f"#,##0.{'0' * currency.decimal_places}"
 
     def create_xlsx_report(self, docids, data):
         objs = self._get_objs_for_report(docids, data)

--- a/report_xlsx/tests/test_report.py
+++ b/report_xlsx/tests/test_report.py
@@ -59,9 +59,5 @@ class TestReport(common.TransactionCase):
     def test_currency_format(self):
         usd = self.env.ref("base.USD")
         self.assertEqual(
-            self.xlsx_report._report_xlsx_currency_format(usd), "$#,##0.00"
-        )
-        eur = self.env.ref("base.EUR")
-        self.assertEqual(
-            self.xlsx_report._report_xlsx_currency_format(eur), "#,##0.00 €"
+            self.xlsx_report._report_xlsx_currency_format(usd), "#,##0.00"
         )


### PR DESCRIPTION
Some xlsx readers doesn't like mixed formats on the same column.
Here we sometimes have the sign on the left, sometimes on the right.
(change introduced in this commit on `account-financial-report` https://github.com/OCA/account-financial-reporting/commit/f088aa6405aac8527cfbd6da2d63dd6aebaf7951#diff-8237378723eb85bb5c6d6e16f339b55840b762029442371284fe1ad71d08c1e2
When it happens, we get `###` displayed (even though value is ok)
-> No, this isn't because of the column being too narrow.

![image](https://github.com/user-attachments/assets/bc5d9f62-fc34-4ac8-b374-c8f83f65fb10)


Among the tested readers, I was able to reproduce on `excel` (asking to repair the file), `onlyoffice` (not proposing any fix) and `gsheet`.


Reverting to a simple number format.

Also, the only report on which this method is `open items` in `account_financial_report`, which also displays the currency in a dedicated column. This information is redundant.