### PR TITLE
[FIX] report_csv: make it working if docids is False

### DIFF
--- a/report_csv/models/ir_report.py
+++ b/report_csv/models/ir_report.py
@@ -55,7 +55,7 @@ class ReportAction(models.Model):
         report_sudo = self._get_report(report_ref)
         report_model_name = "report.%s" % report_sudo.report_name
         report_model = self.env[report_model_name]
-        res_id = len(docids) == 1 and docids[0]
+        res_id = docids[0] if docids and len(docids) == 1 else None
         if not res_id or not report_sudo.attachment or not report_sudo.attachment_use:
             return report_model.with_context(
                 **{

--- a/report_csv/tests/test_report.py
+++ b/report_csv/tests/test_report.py
@@ -97,6 +97,12 @@ class TestReport(common.TransactionCase):
         with self.assertRaises(UserError):
             rep = report._render_csv(self.report_name, self.docs.ids, {})
 
+    def test_report_docids_is_none(self):
+        """
+        Test when docids is None (should not raise TypeError)
+        """
+        self.report_object._render_csv(self.report_name, None, {})
+
 
 class TestCsvReport(common.HttpCase):
     """


### PR DESCRIPTION
len() is used on docids, but in some cases, docids is False wich raised a TypeError