### PR TITLE
[16.0][FIX] report_async: fix mail template

### DIFF
--- a/report_async/data/mail_template.xml
+++ b/report_async/data/mail_template.xml
@@ -2,10 +2,10 @@
     <record id="async_report_delivery" model="mail.template">
         <field name="name">Report Async: New Report Available</field>
         <field name="model_id" ref="base.model_ir_attachment" />
-        <field name="subject">Your report is available, ${object.name}</field>
+        <field name="subject">Your report is available, {{object.name}}</field>
         <field
             name="email_from"
-        >${object.company_id.partner_id.email_formatted|safe}</field>
+        >{{object.company_id.partner_id.email_formatted}}</field>
         <field name="partner_to">{{ user.partner_id.id }}</field>
         <field name="body_html" type="html">
             <table
@@ -38,20 +38,29 @@
                                                     valign="top"
                                                     style="font-size: 13px;"
                                                 >
-                                    % set base_url = object.env['ir.config_parameter'].sudo().get_param('web.base.url')
-                                    % set download_url = '%s/web/content/ir.attachment/%s/datas/%s?download=true' % (base_url, object.id, object.name, )
+                                                <t
+                                                        t-set="base_url"
+                                                        t-value="object.env['ir.config_parameter'].sudo().get_param('web.base.url')"
+                                                    />
+                                                <t
+                                                        t-set="download_url"
+                                                        t-value="'%s/web/content/ir.attachment/%s/datas/%s?download=true' % (base_url, object.id, object.name, )"
+                                                    />
                                     <div>
-                                        Dear ${object.create_uid.partner_id.name or ''},
+                                        Dear <t
+                                                            t-out="object.create_uid.partner_id.name or ''"
+                                                        />,
                                         <br /><br />
-                                        Your requested report, ${object.name}, is available for <b
-                                                        >
+                                        Your requested report, <t
+                                                            t-out="object.name"
+                                                        />, is available for <b>
                                                             <a
-                                                                href='${download_url}'
+                                                                t-attf-href="{{ download_url }}"
                                                             >download</a>
                                                         </b>.
                                         <br /><br />
                                         Have a nice day!<br />
-                                        --<br />${object.company_id.name}
+                                        --<br /><t t-out="object.company_id.name" />
                                     </div>
                                 </td>
                                             </tr>


### PR DESCRIPTION
The mail that was sent when generating a report using jobs and with an email notification wasn't displayed correctly.
I think that the template wasn't correctly migrated.

I didn't modify any behavior, I just 'translated' the template using v16's template standards.