### PR TITLE
[IMP] sql_export_mail, add partner as export email recipient

### DIFF
--- a/sql_export_mail/models/sql_export.py
+++ b/sql_export_mail/models/sql_export.py
@@ -19,6 +19,14 @@ class SqlExport(models.Model):
         help="Add the users who want to receive the report by e-mail. You "
         "need to link the sql query with a cron to send mail automatically",
     )
+    mail_partner_ids = fields.Many2many(
+        "res.partner",
+        "mail_partner_sqlquery_rel",
+        "sql_id",
+        "partner_id",
+        help="Add the partners who wants to receive the report by e-mail. You "
+        "need to link the sql query with a cron to send a mail automatically",
+    )
     cron_ids = fields.Many2many(
         "ir.cron",
         "cron_sqlquery_rel",
@@ -138,13 +146,43 @@ class SqlExport(models.Model):
                 if not user.email:
                     raise UserError(_("The user does not have any e-mail address."))
 
+    @api.constrains("mail_partner_ids", "query")
+    def _check_mail_partner(self):
+        for export in self:
+            if export.mail_partner_ids and (
+                "%(company_id)s" in export.query or "%(user_id)s" in export.query
+            ):
+                raise UserError(
+                    _(
+                        "A query that uses the company_id or user_id parameter "
+                        "cannot be directly sent to a partner."
+                    )
+                )
+            missing_email_partners = export.mail_partner_ids.filtered(
+                lambda partner: not partner.email
+            )
+            if missing_email_partners:
+                raise UserError(
+                    _(
+                        "Missing email address for partner(s): %(names)s",
+                        names=", ".join(missing_email_partners.mapped("name")),
+                    )
+                )
+
     def get_email_address_for_template(self):
         """
-        Called from mail template
+        Called from mail template.
+        Collects email addresses from both users and partners.
         """
         self.ensure_one()
         if self.env.context.get("mail_to"):
             mail_users = self.env["res.users"].browse(self.env.context.get("mail_to"))
+            mail_partners = self.env["res.partner"]
         else:
             mail_users = self.mail_user_ids
-        return ",".join([x.email for x in mail_users if x.email])
+            mail_partners = self.mail_partner_ids
+        email_addresses = set(
+            mail_users.mapped("email") + mail_partners.mapped("email")
+        )
+        email_addresses.discard(False)
+        return ",".join(email_addresses)

--- a/sql_export_mail/static/description/index.html
+++ b/sql_export_mail/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -421,7 +422,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sql_export_mail/tests/test_sql_query_mail.py
+++ b/sql_export_mail/tests/test_sql_query_mail.py
@@ -53,6 +53,13 @@ class TestExportSqlQueryMail(TransactionCase):
         )
         self.check_execution()
 
+    def test_sql_query_mail_partner(self):
+        """Check if emails are sent to partners"""
+        self.check_before_change()
+        partner = self.env.ref("base.res_partner_2")
+        self.sql_report_demo.write({"mail_partner_ids": [(4, partner.id)]})
+        self.check_execution(partner)
+
     def check_before_change(self):
         """Check if there are no mails before changing the sql report"""
         mails = self.env["mail.mail"].search(
@@ -60,7 +67,7 @@ class TestExportSqlQueryMail(TransactionCase):
         )
         self.assertFalse(mails)
 
-    def check_execution(self):
+    def check_execution(self, partner=None):
         """Check if the cron could be created and the mail sending is working"""
         self.sql_report_demo.create_cron()
         self.assertTrue(self.sql_report_demo.cron_ids)
@@ -70,3 +77,5 @@ class TestExportSqlQueryMail(TransactionCase):
         )
         self.assertTrue(mails)
         self.assertTrue(mails.attachment_ids)
+        if partner:
+            self.assertIn(partner.email, mails.mapped("email_to"))

--- a/sql_export_mail/views/sql_export_view.xml
+++ b/sql_export_mail/views/sql_export_view.xml
@@ -31,6 +31,14 @@
                             colspan="2"
                         />
                         </group>
+                        <group string="Partners Notified by e-mail">
+                            <field
+                            name="mail_partner_ids"
+                            nolabel="1"
+                            widget="many2many_tags"
+                            colspan="2"
+                        />
+                        </group>
                         <group string="Crons" groups="base.group_system">
                             <field
                             name="cron_ids"


### PR DESCRIPTION
Adds partner_ids additional to user_ids to send the result of an sql_export by email.
- Doesn't allow the usage of dynamic parameters "user_id" or "company_id" in combination with sending the report to a partner_id. This to prevent unwanted / unfiltered results to recipients.
- Adds the email addresses of selected partners to the email addresses of selected users (if any)