### PR TITLE
[16.0][IMP] report_qweb_field_option: remove odoo_test_helper from manifest

### DIFF
--- a/report_qweb_field_option/__manifest__.py
+++ b/report_qweb_field_option/__manifest__.py
@@ -8,9 +8,6 @@
     "author": "Quartile, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/reporting-engine",
     "depends": ["uom"],
-    "external_dependencies": {
-        "python": ["odoo_test_helper"],
-    },
     "data": [
         "security/ir.model.access.csv",
         "security/qweb_field_options_security.xml",

--- a/report_qweb_field_option/static/description/index.html
+++ b/report_qweb_field_option/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -449,9 +448,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 cryptography
 endesive
 mock
-odoo_test_helper
 openpyxl
 py3o.formats
 py3o.template

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-test-helper


### PR DESCRIPTION
This PR removes the `odoo_test_helper` from the `manifest ` to avoid raising error when install the module in the environment that doesn't install this library and this library is needed for the test cases. So, I added `odoo_test_helper` in `test-requirements.txt` instead.

@qrtl QT5035