### PR TITLE
[14.0] [FIX] report_label: avoid TypeError when viewing qweb templates from action.server form

### DIFF
--- a/report_label/models/ir_actions_server.py
+++ b/report_label/models/ir_actions_server.py
@@ -23,9 +23,7 @@ class IrActionsServer(models.Model):
     def report_label_associated_view(self):
         """View the associated qweb templates"""
         self.ensure_one()
-        res = self.env["ir.actions.act_window"]._for_xml_id(
-            "base.action_ui_view", raise_if_not_found=False
-        )
+        res = self.env["ir.actions.act_window"]._for_xml_id("base.action_ui_view")
         if not res or len(self.label_template.split(".")) < 2:
             return False
         res["domain"] = [


### PR DESCRIPTION
Doing some tests for a customer project we found this issue:

![report_label error when viewing qweb templates](https://github.com/user-attachments/assets/5aff0e98-1b30-4406-a281-29bc6d956fc6)

```
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/addons/web/controllers/main.py", line 1374, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 406, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 391, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/mnt/data/odoo-addons-dir/report_label/models/ir_actions_server.py", line 26, in report_label_associated_view
    res = self.env["ir.actions.act_window"]._for_xml_id(
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: _for_xml_id() got an unexpected keyword argument 'raise_if_not_found'
```


@BinhexTeam