### PR TITLE
[15.0][IMP] report_py3o: add new mixin model

### DIFF
--- a/report_py3o/README.rst
+++ b/report_py3o/README.rst
@@ -50,6 +50,22 @@ This reporting engine is an alternative to `Aeroo <https://github.com/aeroo-comm
 .. contents::
    :local:
 
+Use Cases / Context
+===================
+
+The mixin in the report_py3o module allows to set up a Py3o template at 
+both model and registry level. This significantly extends the capabilities of the 
+report_py3o module, allowing an efficient and centralised customisation of reports in Odoo.
+
+The mixin allows:
+
+* Model Level Management: Associate a default template to a model, so that all its records 
+  can use it as a basis for report generation.
+* Customisation by Record: Allow each individual record to have its own unique template, 
+  tailored to specific needs.
+* Use of Reports with dynamic template: Use a generic report that, thanks to the mixin, 
+  can dynamically adjust the Py3o template according to the model or record being processed.
+
 Installation
 ============
 
@@ -230,6 +246,10 @@ Contributors
 * Holger Brunn <hbrunn@therp.nl>
 * Phuc Tran Thanh <phuc@trobz.com>
 * Alexandre D. Díaz (`Grupo Isonor <alexandrediaz@grupoisonor.es>`_)
+* `Tecnativa <https://www.tecnativa.com>`_
+
+  * Pilar Vargas
+
 
 Maintainers
 ~~~~~~~~~~~

--- a/report_py3o/models/ir_actions_report.py
+++ b/report_py3o/models/ir_actions_report.py
@@ -24,7 +24,8 @@ class IrActionsReport(models.Model):
     The list is configurable in the configuration tab, see py3o_template.py
     """
 
-    _inherit = "ir.actions.report"
+    _name = "ir.actions.report"
+    _inherit = ["ir.actions.report", "py3o.template.mixin"]
 
     @api.constrains("py3o_filetype", "report_type")
     def _check_py3o_filetype(self):
@@ -57,7 +58,6 @@ class IrActionsReport(models.Model):
         selection="_get_py3o_filetypes", string="Output Format"
     )
     is_py3o_native_format = fields.Boolean(compute="_compute_is_py3o_native_format")
-    py3o_template_id = fields.Many2one("py3o.template", "Template")
     module = fields.Char(help="The implementer module that provides this report")
     py3o_template_fallback = fields.Char(
         "Fallback",

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -164,10 +164,16 @@ class Py3oReport(models.TransientModel):
         if report_xml.py3o_template_id.py3o_template_data:
             # if a user gave a report template
             tmpl_data = b64decode(report_xml.py3o_template_id.py3o_template_data)
-
         else:
             tmpl_data = self._get_template_fallback(model_instance)
-
+            if (
+                not tmpl_data
+                and "py3o_template_id" in model_instance._fields
+                and model_instance.py3o_template_id
+            ):
+                tmpl_data = b64decode(
+                    model_instance.py3o_template_id.py3o_template_data
+                )
         if tmpl_data is None:
             # if for any reason the template is not found
             raise TemplateNotFound(_("No template found. Aborting."), sys.exc_info())

--- a/report_py3o/models/py3o_template.py
+++ b/report_py3o/models/py3o_template.py
@@ -1,4 +1,5 @@
 # Copyright 2013 XCG Consulting (http://odoo.consulting)
+# Copyright 2025 Tecnativa - Pilar Vargas
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
@@ -22,3 +23,12 @@ class Py3oTemplate(models.Model):
         required=True,
         default="odt",
     )
+
+
+class Py3oTemplateMixin(models.AbstractModel):
+    _name = "py3o.template.mixin"
+    _description = "Py3o template mixin"
+
+    # Extending a model with this mixin allows to establish a py3o template at model
+    # and record level.
+    py3o_template_id = fields.Many2one("py3o.template", "Template")

--- a/report_py3o/readme/CONTEXT.rst
+++ b/report_py3o/readme/CONTEXT.rst
@@ -1,0 +1,12 @@
+The mixin in the report_py3o module allows to set up a Py3o template at 
+both model and registry level. This significantly extends the capabilities of the 
+report_py3o module, allowing an efficient and centralised customisation of reports in Odoo.
+
+The mixin allows:
+
+* Model Level Management: Associate a default template to a model, so that all its records 
+  can use it as a basis for report generation.
+* Customisation by Record: Allow each individual record to have its own unique template, 
+  tailored to specific needs.
+* Use of Reports with dynamic template: Use a generic report that, thanks to the mixin, 
+  can dynamically adjust the Py3o template according to the model or record being processed.

--- a/report_py3o/readme/CONTRIBUTORS.rst
+++ b/report_py3o/readme/CONTRIBUTORS.rst
@@ -6,3 +6,7 @@
 * Holger Brunn <hbrunn@therp.nl>
 * Phuc Tran Thanh <phuc@trobz.com>
 * Alexandre D. Díaz (`Grupo Isonor <alexandrediaz@grupoisonor.es>`_)
+* `Tecnativa <https://www.tecnativa.com>`_
+
+  * Pilar Vargas
+

--- a/report_py3o/static/description/index.html
+++ b/report_py3o/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -388,28 +388,44 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
-<li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a><ul>
-<li><a class="reference internal" href="#configuration-parameters" id="toc-entry-3">Configuration parameters</a></li>
+<li><a class="reference internal" href="#use-cases-context" id="toc-entry-1">Use Cases / Context</a></li>
+<li><a class="reference internal" href="#installation" id="toc-entry-2">Installation</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-3">Configuration</a><ul>
+<li><a class="reference internal" href="#configuration-parameters" id="toc-entry-4">Configuration parameters</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#usage" id="toc-entry-4">Usage</a><ul>
-<li><a class="reference internal" href="#available-functions-and-objects" id="toc-entry-5">Available functions and objects</a></li>
-<li><a class="reference internal" href="#sample-report-templates" id="toc-entry-6">Sample report templates</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-5">Usage</a><ul>
+<li><a class="reference internal" href="#available-functions-and-objects" id="toc-entry-6">Available functions and objects</a></li>
+<li><a class="reference internal" href="#sample-report-templates" id="toc-entry-7">Sample report templates</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-7">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-8">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-9">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-10">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-11">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-12">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-8">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-9">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-10">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-11">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-12">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-13">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="use-cases-context">
+<h1><a class="toc-backref" href="#toc-entry-1">Use Cases / Context</a></h1>
+<p>The mixin in the report_py3o module allows to set up a Py3o template at
+both model and registry level. This significantly extends the capabilities of the
+report_py3o module, allowing an efficient and centralised customisation of reports in Odoo.</p>
+<p>The mixin allows:</p>
+<ul class="simple">
+<li>Model Level Management: Associate a default template to a model, so that all its records
+can use it as a basis for report generation.</li>
+<li>Customisation by Record: Allow each individual record to have its own unique template,
+tailored to specific needs.</li>
+<li>Use of Reports with dynamic template: Use a generic report that, thanks to the mixin,
+can dynamically adjust the Py3o template according to the model or record being processed.</li>
+</ul>
+</div>
 <div class="section" id="installation">
-<h1><a class="toc-backref" href="#toc-entry-1">Installation</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Installation</a></h1>
 <p>Install the required python libs:</p>
 <pre class="code literal-block">
 pip install py3o.template
@@ -421,7 +437,7 @@ apt-get --no-install-recommends install libreoffice
 </pre>
 </div>
 <div class="section" id="configuration">
-<h1><a class="toc-backref" href="#toc-entry-2">Configuration</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Configuration</a></h1>
 <p>For example, to replace the native invoice report by a custom py3o report, add the following XML file in your custom module:</p>
 <pre class="code literal-block">
 &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
@@ -497,7 +513,7 @@ root_tmpl_path=/odoo/templates/py3o
 &lt;/odoo&gt;
 </pre>
 <div class="section" id="configuration-parameters">
-<h2><a class="toc-backref" href="#toc-entry-3">Configuration parameters</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Configuration parameters</a></h2>
 <dl class="docutils">
 <dt>py3o.conversion_command</dt>
 <dd>The command to be used to run the conversion, <tt class="docutils literal">libreoffice</tt> by default. If you change this, whatever you set here must accept the parameters <tt class="docutils literal"><span class="pre">--headless</span> <span class="pre">--convert-to</span> $ext $file</tt> and put the resulting file into <tt class="docutils literal">$file</tt>’s directory with extension <tt class="docutils literal">$ext</tt>. The command will be started in <tt class="docutils literal">$file</tt>’s directory.</dd>
@@ -505,10 +521,10 @@ root_tmpl_path=/odoo/templates/py3o
 </div>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-4">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Usage</a></h1>
 <p>The templating language is <a class="reference external" href="http://py3otemplate.readthedocs.io/en/latest/templating.html">extensively documented</a>, the records are exposed in libreoffice as <tt class="docutils literal">objects</tt>, on which you can also call functions.</p>
 <div class="section" id="available-functions-and-objects">
-<h2><a class="toc-backref" href="#toc-entry-5">Available functions and objects</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Available functions and objects</a></h2>
 <dl class="docutils">
 <dt>user</dt>
 <dd>Browse record of current user</dd>
@@ -531,12 +547,12 @@ root_tmpl_path=/odoo/templates/py3o
 </dl>
 </div>
 <div class="section" id="sample-report-templates">
-<h2><a class="toc-backref" href="#toc-entry-6">Sample report templates</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Sample report templates</a></h2>
 <p>Sample py3o report templates for the main Odoo native reports (invoice, sale order, purchase order, picking, etc.) are available on the Github project <a class="reference external" href="https://github.com/akretion/odoo-py3o-report-templates">odoo-py3o-report-templates</a>.</p>
 </div>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-7">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-8">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>generate barcode ?</li>
 <li>add more detailed example in demo file to showcase features</li>
@@ -544,7 +560,7 @@ root_tmpl_path=/odoo/templates/py3o
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-8">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-9">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/reporting-engine/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -552,16 +568,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-9">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-10">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-10">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Authors</a></h2>
 <ul class="simple">
 <li>XCG Consulting</li>
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-11">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-12">Contributors</a></h2>
 <ul class="simple">
 <li>Florent Aide (<a class="reference external" href="http://odoo.consulting/">XCG Consulting</a>)</li>
 <li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;,</li>
@@ -571,12 +587,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Holger Brunn &lt;<a class="reference external" href="mailto:hbrunn&#64;therp.nl">hbrunn&#64;therp.nl</a>&gt;</li>
 <li>Phuc Tran Thanh &lt;<a class="reference external" href="mailto:phuc&#64;trobz.com">phuc&#64;trobz.com</a>&gt;</li>
 <li>Alexandre D. Díaz (<a class="reference external" href="mailto:alexandrediaz&#64;grupoisonor.es">Grupo Isonor</a>)</li>
+<li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a><ul>
+<li>Pilar Vargas</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-12">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-13">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Extending a model with this mixin allows to set a py3o template at model and record level.

Using a common report it is possible to print a custom py3o template by setting that template at model and record level.
A use case could be to want to print the invoice reports of a contact by customising those reports using a py3o template. You would extend the res.partner model to be able to add the template to that contact and have a related on the invoices to print that custom report.

cc @Tecnativa TT55652

@chienandalu @pedrobaeza @victoralmau please review