### PR TITLE
[14.0][IMP] translate filename xlsx

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -39,7 +39,10 @@ class ReportController(report.ReportController):
             report_name = report.name
             if report.print_report_name and not len(docids) > 1:
                 obj = request.env[report.model].browse(docids[0])
-                report_name = safe_eval(report.print_report_name, {"object": obj})
+                lang = obj.lang if hasattr(obj, "lang") else request.env.user.lang
+                report_name = safe_eval(
+                    report.with_context(lang=lang).print_report_name, {"object": obj}
+                )
             xlsxhttpheaders = [
                 (
                     "Content-Type",


### PR DESCRIPTION
The name of the downloaded file is always in the user language.

With this PR the name is translatable on the `object.lang` field [to be added to the object used to create the report].