### PR TITLE
[17.0][FIX] report_qweb_pdf_watermark: Recursive call in report rendering

### DIFF
--- a/report_qweb_pdf_watermark/README.rst
+++ b/report_qweb_pdf_watermark/README.rst
@@ -145,6 +145,7 @@ Contributors
 - Emiel van Bokhoven <emiel@360erp.nl>
 - Sander Lienaerts <sander.lienaerts@codeforward.nl>
 - Anjeel Haria
+- Deniz Gallo <dgallo@nuobit.com>
 
 Maintainers
 -----------

--- a/report_qweb_pdf_watermark/models/report.py
+++ b/report_qweb_pdf_watermark/models/report.py
@@ -1,5 +1,6 @@
 # © 2016 Therp BV <http://therp.nl>
 # Copyright 2023 Onestein - Anjeel Haria
+# Copyright 2025 NuoBiT - Deniz Gallo <dgallo@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from base64 import b64decode
 from io import BytesIO
@@ -44,10 +45,8 @@ class Report(models.Model):
 
     def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         if not self.env.context.get("res_ids"):
-            return (
-                super()
-                .with_context(res_ids=res_ids)
-                ._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
+            return super(Report, self.with_context(res_ids=res_ids))._render_qweb_pdf(
+                report_ref, res_ids=res_ids, data=data
             )
         return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
 

--- a/report_qweb_pdf_watermark/readme/CONTRIBUTORS.md
+++ b/report_qweb_pdf_watermark/readme/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 - Emiel van Bokhoven \<<emiel@360erp.nl>\>
 - Sander Lienaerts \<<sander.lienaerts@codeforward.nl>\>
 - Anjeel Haria
+- Deniz Gallo \<<dgallo@nuobit.com>\>

--- a/report_qweb_pdf_watermark/static/description/index.html
+++ b/report_qweb_pdf_watermark/static/description/index.html
@@ -506,6 +506,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Emiel van Bokhoven &lt;<a class="reference external" href="mailto:emiel&#64;360erp.nl">emiel&#64;360erp.nl</a>&gt;</li>
 <li>Sander Lienaerts &lt;<a class="reference external" href="mailto:sander.lienaerts&#64;codeforward.nl">sander.lienaerts&#64;codeforward.nl</a>&gt;</li>
 <li>Anjeel Haria</li>
+<li>Deniz Gallo &lt;<a class="reference external" href="mailto:dgallo&#64;nuobit.com">dgallo&#64;nuobit.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
This PR fixes a RecursionError caused by an infinite recursive call that occurs in the _render_qweb_pdf method.

![Captura de pantalla de 2025-04-25 11-11-36](https://github.com/user-attachments/assets/d4853301-f812-488a-9374-9d51c1a9ba71)

@dreispt @eantones @FrankC013 can you please review