### PR TITLE
[16.0][FIX] The field cron_id should be copy=False

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -188,7 +188,7 @@ class BiSQLView(models.Model):
         readonly=True,
         help="Cron Task that will refresh the materialized view",
         ondelete="cascade",
-        copy=False
+        copy=False,
     )
 
     rule_id = fields.Many2one(string="Odoo Rule", comodel_name="ir.rule", readonly=True)

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -188,6 +188,7 @@ class BiSQLView(models.Model):
         readonly=True,
         help="Cron Task that will refresh the materialized view",
         ondelete="cascade",
+        copy=False
     )
 
     rule_id = fields.Many2one(string="Odoo Rule", comodel_name="ir.rule", readonly=True)


### PR DESCRIPTION
Hi,

When you duplicate a V1 materialized SQL view to make a new V2 version, for example, the cron remains the same.
However, in the cron line model._refresh_materialized_view_cron([id]), the id is that of the old V1 version and so our V2 view is never refreshed.

Makes sense. The field cron_id should be copy=False. Could you make a PR ?
Ideally upstream also. (On V18 branch)
Thanks !