### PR TITLE
[18.0][FIX] The field cron_id should be copy=False

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -150,6 +150,7 @@ class BiSQLView(models.Model):
         comodel_name="ir.cron",
         help="Cron Task that will refresh the materialized view",
         ondelete="cascade",
+        copy=False,
     )
 
     rule_id = fields.Many2one(string="Odoo Rule", comodel_name="ir.rule")


### PR DESCRIPTION
Same patch of V16 for V18 !


When you duplicate a V1 materialized SQL view to make a new V2 version, for example, the cron remains the same.
However, in the cron line model._refresh_materialized_view_cron([id]), the id is that of the old V1 version and so our V2 view is never refreshed.

Makes sense. The field cron_id should be copy=False.