### PR TITLE
[18.0][FIX] bi_sql_editor: Replace deprecated `datetime.utcnow()`

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from psycopg2 import ProgrammingError
 from psycopg2.sql import SQL, Identifier
@@ -489,7 +489,7 @@ class BiSQLView(models.Model):
             return self.name
         return "{} ({})".format(
             self.name,
-            datetime.utcnow().strftime("%m/%d/%Y %H:%M:%S UTC"),
+            datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S UTC"),
         )
 
     def _prepare_menu(self):


### PR DESCRIPTION
[FIX] bi_sql_editor: Replace deprecated `datetime.utcnow()`

Replace deprecated `datetime.utcnow()` with timezone-aware equivalent
`datetime.now(timezone.utc)` to resolve Python 3.12+ deprecation warnings.

Affected files:
- bi_sql_editor/models/bi_sql_view.py