### PR TITLE
[18.0][IMP] report_qweb_pdf_watermark: support pypdf >= 2.0

### DIFF
--- a/report_qweb_pdf_watermark/README.rst
+++ b/report_qweb_pdf_watermark/README.rst
@@ -88,38 +88,38 @@ Changelog
 12.0.1.0.0 (2019-11-18)
 -----------------------
 
-- [MIG] Migration to V12.
+-  [MIG] Migration to V12.
 
 13.0.1.0.0 (2021-01-27)
 -----------------------
 
-- [MIG] Migration to V13.
+-  [MIG] Migration to V13.
 
 14.0.1.0.0 (2021-01-29)
 -----------------------
 
-- [MIG] Migration to V14.
+-  [MIG] Migration to V14.
 
 15.0.1.0.0 (2022-01-11)
 -----------------------
 
-- [MIG] Migration to V15.
-- Define pdf watermark in company settings
+-  [MIG] Migration to V15.
+-  Define pdf watermark in company settings
 
 16.0.1.0.0 (2023-03-13)
 -----------------------
 
-- [MIG] Migration to V16.
+-  [MIG] Migration to V16.
 
 17.0.1.0.0 (2024-01-12)
 -----------------------
 
-- [MIG] Migration to V17.
+-  [MIG] Migration to V17.
 
 18.0.1.0.0 (2025-01-06)
 -----------------------
 
-- [MIG] Migration to V18.
+-  [MIG] Migration to V18.
 
 Bug Tracker
 ===========
@@ -142,14 +142,14 @@ Authors
 Contributors
 ------------
 
-- Holger Brunn <hbrunn@therp.nl>
-- Stefan Rijnhart <stefan@opener.am>
-- Rod Schouteden <rod.schouteden@dynapps.be>
-- Robin Goots <robin.goots@dynapps.be>
-- Foram Shah <foram.shah@initos.com>
-- bosd <c5e2fd43-d292-4c90-9d1f-74ff3436329a@anonaddy.me>
-- Sander Lienaerts <sander.lienaerts@codeforward.nl>
-- Anjeel Haria
+-  Holger Brunn <hbrunn@therp.nl>
+-  Stefan Rijnhart <stefan@opener.am>
+-  Rod Schouteden <rod.schouteden@dynapps.be>
+-  Robin Goots <robin.goots@dynapps.be>
+-  Foram Shah <foram.shah@initos.com>
+-  bosd <c5e2fd43-d292-4c90-9d1f-74ff3436329a@anonaddy.me>
+-  Sander Lienaerts <sander.lienaerts@codeforward.nl>
+-  Anjeel Haria
 
 Maintainers
 -----------
@@ -163,6 +163,14 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-hbrunn| image:: https://github.com/hbrunn.png?size=40px
+    :target: https://github.com/hbrunn
+    :alt: hbrunn
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-hbrunn| 
 
 This module is part of the `OCA/reporting-engine <https://github.com/OCA/reporting-engine/tree/18.0/report_qweb_pdf_watermark>`_ project on GitHub.
 

--- a/report_qweb_pdf_watermark/__manifest__.py
+++ b/report_qweb_pdf_watermark/__manifest__.py
@@ -10,6 +10,7 @@
     "summary": "Add watermarks to your QWEB PDF reports",
     "website": "https://github.com/OCA/reporting-engine",
     "depends": ["web"],
+    "maintainers": ["hbrunn"],
     "data": [
         "views/ir_actions_report_xml.xml",
         "views/res_company.xml",

--- a/report_qweb_pdf_watermark/models/report.py
+++ b/report_qweb_pdf_watermark/models/report.py
@@ -19,10 +19,19 @@ except ImportError:
     logger.error("ImportError: The PdfImagePlugin could not be imported")
 
 try:
-    from PyPDF2 import PdfFileReader, PdfFileWriter  # pylint: disable=W0404
-    from PyPDF2.utils import PdfReadError  # pylint: disable=W0404
+    try:
+        from PyPDF2 import PdfReader, PdfWriter  # pylint: disable=W0404
+        from PyPDF2.errors import PdfReadError  # pypdf >= 2.0
+    except ImportError:
+        from PyPDF2 import (  # pylint: disable=W0404
+            PdfFileReader as PdfReader,
+        )
+        from PyPDF2 import (
+            PdfFileWriter as PdfWriter,
+        )
+        from PyPDF2.utils import PdfReadError  # pypdf < 2.0
 except ImportError:
-    logger.debug("Can not import PyPDF2")
+    logger.warning("Can not import PyPDF2")
 
 
 class Report(models.Model):
@@ -105,11 +114,11 @@ class Report(models.Model):
         if not watermark:
             return result
 
-        pdf = PdfFileWriter()
+        pdf = PdfWriter()
         pdf_watermark = None
         try:
-            pdf_watermark = PdfFileReader(BytesIO(watermark))
-        except PdfReadError:
+            pdf_watermark = PdfReader(BytesIO(watermark))
+        except (UnicodeDecodeError, PdfReadError):
             # let's see if we can convert this with pillow
             try:
                 Image.init()
@@ -121,7 +130,7 @@ class Report(models.Model):
                 if isinstance(resolution, tuple):
                     resolution = resolution[0]
                 image.save(pdf_buffer, "pdf", resolution=resolution)
-                pdf_watermark = PdfFileReader(pdf_buffer)
+                pdf_watermark = PdfReader(pdf_buffer)
             except Exception as e:
                 logger.exception("Failed to load watermark", e)
 
@@ -132,12 +141,16 @@ class Report(models.Model):
         if not self.pdf_has_usable_pages(pdf_watermark.numPages):
             return result
 
-        for page in PdfFileReader(BytesIO(result)).pages:
+        for page in PdfReader(BytesIO(result)).pages:
             watermark_page = pdf.addBlankPage(
                 page.mediaBox.getWidth(), page.mediaBox.getHeight()
             )
-            watermark_page.mergePage(pdf_watermark.getPage(0))
-            watermark_page.mergePage(page)
+            # merge_page is >= 2.0, mergePage < 2.0
+            merge_page = (
+                getattr(watermark_page, "merge_page", None) or watermark_page.mergePage
+            )
+            merge_page(pdf_watermark.getPage(0))
+            merge_page(page)
 
         pdf_content = BytesIO()
         pdf.write(pdf_content)

--- a/report_qweb_pdf_watermark/static/description/index.html
+++ b/report_qweb_pdf_watermark/static/description/index.html
@@ -524,6 +524,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/hbrunn"><img alt="hbrunn" src="https://github.com/hbrunn.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/reporting-engine/tree/18.0/report_qweb_pdf_watermark">OCA/reporting-engine</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
forward port of https://github.com/OCA/reporting-engine/pull/952