### PR TITLE
[12.0][IMP] report_xlsx: Allow context when data not provided + force the lang on context

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -30,6 +30,9 @@ class ReportController(report.ReportController):
                     data['context'] = json.loads(data['context'])
                     if data['context'].get('lang'):
                         del data['context']['lang']
+                    # Allow forcing languange explicitly
+                    if data['context'].get('force_lang'):
+                        data['context']['lang'] = data['context']['force_lang']
                     context.update(data['context'])
                 xlsx = report.with_context(context).render_xlsx(
                     docids, data=data

--- a/report_xlsx/static/src/js/report/action_manager_report.js
+++ b/report_xlsx/static/src/js/report/action_manager_report.js
@@ -25,6 +25,9 @@ odoo.define("report_xlsx.report", function (require) {
                 if (cloned_action.context.active_ids) {
                     url += "/" + cloned_action.context.active_ids.join(',');
                 }
+                if (cloned_action.context) {
+                    url += "?context=" + encodeURIComponent(JSON.stringify(cloned_action.context));
+                }
             } else {
                 url += "?options=" + encodeURIComponent(JSON.stringify(cloned_action.data));
                 url += "&context=" + encodeURIComponent(JSON.stringify(cloned_action.context));


### PR DESCRIPTION
Right now in v12 report_xlsx remove the context and also explicitly the lang in context. Allow to manipulate it.