### PR TITLE
[17.0][IMP] base_comment_template: Allow creation of global templates

### DIFF
--- a/base_comment_template/models/base_comment_template.py
+++ b/base_comment_template/models/base_comment_template.py
@@ -42,6 +42,7 @@ class BaseCommentTemplate(models.Model):
         help="If set, the comment template will be available only for the selected "
         "company.",
     )
+    global_template = fields.Boolean()
     partner_ids = fields.Many2many(
         comodel_name="res.partner",
         relation="base_comment_template_res_partner_rel",

--- a/base_comment_template/models/comment_template.py
+++ b/base_comment_template/models/comment_template.py
@@ -41,7 +41,11 @@ class CommentTemplate(models.AbstractModel):
             templates = template_model.search(
                 expression.AND(
                     [
-                        [("id", "in", partner.base_comment_template_ids.ids)],
+                        [
+                            "|",
+                            ("id", "in", partner.base_comment_template_ids.ids),
+                            ("global_template", "=", True),
+                        ],
                         template_domain,
                     ]
                 )

--- a/base_comment_template/models/res_partner.py
+++ b/base_comment_template/models/res_partner.py
@@ -14,6 +14,7 @@ class ResPartner(models.Model):
         column1="res_partner_id",
         column2="base_comment_template_id",
         string="Comment Templates",
+        domain=[("global_template", "=", False)],
         help="Specific partner comments that can be included in reports",
     )
 

--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -87,6 +87,23 @@ class TestCommentTemplate(common.TransactionCase):
         self.assertTrue(self.before_template_id in self.user.comment_template_ids)
         self.assertTrue(self.after_template_id in self.user.comment_template_ids)
 
+    def test_global_template(self):
+        # Need to force _compute because only trigger when partner_id have changed
+        global_template = self.env["base.comment.template"].create(
+            {
+                "name": "Top template",
+                "text": "Text before lines",
+                "models": self.user_obj.model,
+                "company_id": self.company.id,
+            }
+        )
+        self.user._compute_comment_template_ids()
+        # Check getting default comment template
+        self.assertNotIn(global_template, self.user.comment_template_ids)
+        global_template.global_template = True
+        self.user._compute_comment_template_ids()
+        self.assertIn(global_template, self.user.comment_template_ids)
+
     def test_partner_template(self):
         self.partner2_id.base_comment_template_ids = [
             (4, self.before_template_id.id),

--- a/base_comment_template/views/base_comment_template_view.xml
+++ b/base_comment_template/views/base_comment_template_view.xml
@@ -10,6 +10,7 @@
                 <field name="position" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="partner_ids" />
+                <field name="global_template" />
                 <field name="models" />
                 <field name="model_ids" groups="base.group_erp_manager" />
                 <field name="domain" />
@@ -71,6 +72,7 @@
                             <field name="domain" />
                             <field name="models" />
                             <field name="partner_ids" widget="many2many_tags" />
+                            <field name="global_template" />
                             <field name="engine" groups="base.group_no_one" />
                         </group>
                     </group>


### PR DESCRIPTION
On 14, we had that comments not assigned to partners where global. After 15, it was removed.

I agree that the change makes a lot of sense, but we lost an interesting functionality and I think it can be restored by using a boolean field. WDYT?

@victoralmau @pedrobaeza 