### PR TITLE
[16.0][FIX] report_qweb_field_option: fix not working for uom specific

### DIFF
--- a/report_qweb_field_option/models/ir_qweb.py
+++ b/report_qweb_field_option/models/ir_qweb.py
@@ -22,6 +22,7 @@ class IrQweb(models.AbstractModel):
                     ("company_id", "=", False),
                 ]
             )
+            options_recs = [r for r in options_recs if r._get_score(record) > 0]
             if options_recs:
                 options_rec = max(
                     options_recs, default=None, key=lambda r: r._get_score(record)

--- a/report_qweb_field_option/tests/test_models.py
+++ b/report_qweb_field_option/tests/test_models.py
@@ -7,6 +7,8 @@ class TestQwebFieldModel(models.Model):
     _name = "test.qweb.field.options"
 
     name = fields.Char()
+    quantity = fields.Float()
+    uom_id = fields.Many2one("uom.uom")
     value = fields.Float(string="Rounding Factor")
     currency_id = fields.Many2one("res.currency")
     company_id = fields.Many2one("res.company")

--- a/report_qweb_field_option/tests/test_report_qweb_field_options.py
+++ b/report_qweb_field_option/tests/test_report_qweb_field_options.py
@@ -19,6 +19,12 @@ class TestQwebFieldOptions(TransactionCase):
         cls.test_model = cls.env.ref(
             "report_qweb_field_option.model_test_qweb_field_options"
         )
+        cls.quantity_field = cls.env["ir.model.fields"]._get(
+            "test.qweb.field.options", "quantity"
+        )
+        cls.uom_field = cls.env["ir.model.fields"]._get(
+            "test.qweb.field.options", "uom_id"
+        )
         cls.value_field = cls.env["ir.model.fields"]._get(
             "test.qweb.field.options", "value"
         )
@@ -29,9 +35,11 @@ class TestQwebFieldOptions(TransactionCase):
         cls.test_currency = cls.env["res.currency"].create(
             {"name": "Test Currency", "symbol": "$"}
         )
+        cls.unit_uom = cls.env.ref("uom.product_uom_unit")
         cls.test_record = cls.env["test.qweb.field.options"].create(
             {
                 "name": "Test",
+                "quantity": 1.00,
                 "value": 1.00,
                 "currency_id": cls.test_currency.id,
                 "company_id": cls.env.company.id,
@@ -44,6 +52,15 @@ class TestQwebFieldOptions(TransactionCase):
                 "currency_id": cls.test_currency.id,
                 "currency_field_id": cls.currency_field.id,
                 "digits": 0,
+            }
+        )
+        cls.env["qweb.field.options"].create(
+            {
+                "res_model_id": cls.test_model.id,
+                "field_id": cls.quantity_field.id,
+                "uom_id": cls.unit_uom.id,
+                "uom_field_id": cls.uom_field.id,
+                "digits": 3,
             }
         )
 
@@ -123,3 +140,16 @@ class TestQwebFieldOptions(TransactionCase):
         )
         self.assertNotEqual(content, "1.0")
         self.assertNotIn("$", content)
+
+    def test_qweb_field_option_with_uom(self):
+        values = {"report_type": "pdf"}
+        self.test_record.uom_id = self.unit_uom.id
+        _, content, _ = self.IrQweb._get_field(
+            self.test_record, "quantity", False, False, {}, values
+        )
+        self.assertEqual(content, "1.000")
+        self.test_record.uom_id = self.env.ref("uom.product_uom_dozen").id
+        _, content, _ = self.IrQweb._get_field(
+            self.test_record, "quantity", False, False, {}, values
+        )
+        self.assertEqual(content, "1.0")


### PR DESCRIPTION
This PR fixes an issue where a matching record was incorrectly used to update options, even when other attributes did not match. Specifically, if a record had the same model name and field name but other attributes differed, its `_get_score()` would return `-1`. However, it was still being selected by `max()`, resulting in incorrect option updates. This PR ensures that records with a score of `-1 `are excluded from consideration.

@qrtl QT5610