### PR TITLE
[17.0][FIX] report_async: fix dynamic domain for report template

### DIFF
--- a/report_async/wizard/print_report_wizard.py
+++ b/report_async/wizard/print_report_wizard.py
@@ -13,6 +13,7 @@ class PrintReportWizard(models.TransientModel):
         selection="_reference_models",
         required=True,
     )
+    reference_model = fields.Char(compute="_compute_reference_model")
     action_report_id = fields.Many2one(
         comodel_name="ir.actions.report",
         string="Report Template",
@@ -31,14 +32,18 @@ class PrintReportWizard(models.TransientModel):
         )
         return [(model.model, model.name) for model in models]
 
+    @api.depends("reference")
+    def _compute_reference_model(self):
+        for record in self:
+            if record.reference:
+                record.reference_model = record.reference._name
+            else:
+                record.reference_model = False
+
     @api.onchange("reference")
     def _onchange_reference(self):
         self.ensure_one()
-        domain = [("id", "in", [])]
         self.action_report_id = False
-        if self.reference:
-            domain = [("model", "=", self.reference._name)]
-        return {"domain": {"action_report_id": domain}}
 
     def print_report(self):
         self.ensure_one()

--- a/report_async/wizard/print_report_wizard.xml
+++ b/report_async/wizard/print_report_wizard.xml
@@ -10,9 +10,11 @@
                         <field name="reference" />
                     </group>
                     <group>
+                        <field name="reference_model" invisible="1" />
                         <field
                             name="action_report_id"
                             options="{'no_open': True, 'no_create_edit': True}"
+                            domain="[('model', '=', reference_model)] if reference_model else [('id', 'in', [])]"
                         />
                     </group>
                 </group>


### PR DESCRIPTION
<img width="1135" height="535" alt="image" src="https://github.com/user-attachments/assets/2e55a3f6-c70c-4a6d-b397-c7b5e43e7fb3" />


some reason context is no longer present in python dynamic domains, see example here: https://github.com/odoo/odoo/commit/6828dd3489