### PR TITLE
[18.0][FIX] bi_sql_editor: replaces deprecated group_operator by aggregator

### DIFF
--- a/bi_sql_editor/__manifest__.py
+++ b/bi_sql_editor/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "BI SQL Editor",
     "summary": "BI Views builder, based on Materialized or Normal SQL Views",
-    "version": "18.0.1.0.2",
+    "version": "18.0.1.0.3",
     "license": "AGPL-3",
     "category": "Reporting",
     "author": "GRAP,Odoo Community Association (OCA)",

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -724,7 +724,7 @@ WHERE
                     and sql_field[1] in ("integer", "float")
                     and sql_field[2]
                 ):
-                    model._fields[sql_field[0]].group_operator = sql_field[2]
+                    model._fields[sql_field[0]].aggregator = sql_field[2]
 
     def button_preview_sql_expression(self):
         self.button_validate_sql_expression()


### PR DESCRIPTION
I noticed that group operators (e.g. `avg`) were not working correctly in v18, and the values were just summed.

Haven't analysed why the `group_operator` is not used as [this deprecation code](https://github.com/odoo/odoo/blob/18.0/odoo/fields.py#L483) should be able to handle it.

Also see:
* https://github.com/odoo/odoo/pull/127353/commits/e0280ed070c7927b8b8e8933ba381199a6a1ed4c