### PR TITLE
[18.0][FIX] report_xlsx: Preserve custom context by using context from report instead of user context

### DIFF
--- a/report_xlsx/static/src/js/report/action_manager_report.esm.js
+++ b/report_xlsx/static/src/js/report/action_manager_report.esm.js
@@ -8,8 +8,14 @@ registry
         if (action.report_type === "xlsx") {
             const type = action.report_type;
             let url = `/report/${type}/${action.report_name}`;
+            for (const key_data in action.data) {
+                action.context[key_data] = action.data[key_data];
+            }
             const actionContext = action.context || {};
             if (action.data && JSON.stringify(action.data) !== "{}") {
+                if (!url.includes(`/${actionContext.active_id}`)) {
+                    url += `/${actionContext.active_id}`;
+                }
                 // Build a query string with `action.data` (it's the place where reports
                 // using a wizard to customize the output traditionally put their options)
                 const action_options = encodeURIComponent(JSON.stringify(action.data));
@@ -30,7 +36,7 @@ registry
                     url: "/report/download",
                     data: {
                         data: JSON.stringify([url, action.report_type]),
-                        context: JSON.stringify(user.context),
+                        context: JSON.stringify(actionContext),
                     },
                 });
             } finally {


### PR DESCRIPTION
Steps to Reproduce:

Try to set with_context when print the XLSX report. for example with_context(uom_id=1).
when print the report the context uom_id never show up.
**Observer Behavior**
Currently, when trying to send the context through the xlsx report action, the context is always replaced by the default context of Odoo. Hence, the report cannot render data dynamically based on the context when calling report action.

**Expected Behavior**
The context of action report should be taken into account instead of context(this will include env.services.user.context) of env.services.user.context.