### PR TITLE
[FIX] *: align inherited method signature with odoo update

### DIFF
--- a/report_py3o/controllers/main.py
+++ b/report_py3o/controllers/main.py
@@ -57,7 +57,7 @@ class ReportController(ReportControllerBase):
         return request.make_response(res, headers=http_headers)
 
     @route()
-    def report_download(self, data, context=None, token=None):
+    def report_download(self, data, context=None, token=None, readonly=True):
         """This function is used by 'qwebactionmanager.js' in order to trigger
         the download of a py3o/controller report.
 
@@ -68,7 +68,9 @@ class ReportController(ReportControllerBase):
         requestcontent = json.loads(data)
         url, report_type = requestcontent[0], requestcontent[1]
         if "py3o" not in report_type:
-            return super().report_download(data, context=context, token=token)
+            return super().report_download(
+                data, context, token=token, readonly=readonly
+            )
         try:
             reportname = url.split("/report/py3o/")[1].split("?")[0]
             docids = None

--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -51,7 +51,7 @@ class ReportController(ReportController):
         return super().report_routes(reportname, docids, converter, **data)
 
     @route()
-    def report_download(self, data, context=None, token=None):
+    def report_download(self, data, context=None, token=None, readonly=True):
         requestcontent = json.loads(data)
         url, report_type = requestcontent[0], requestcontent[1]
         if report_type == "xlsx":
@@ -104,4 +104,6 @@ class ReportController(ReportController):
                 error = {"code": 200, "message": "Odoo Server Error", "data": se}
                 return request.make_response(html_escape(json.dumps(error)))
         else:
-            return super().report_download(data, context=context, token=token)
+            return super().report_download(
+                data, context, token=token, readonly=readonly
+            )

--- a/report_xml/controllers/report.py
+++ b/report_xml/controllers/report.py
@@ -48,12 +48,14 @@ class ReportController(report.ReportController):
         return request.make_response(xml, headers=xmlhttpheaders)
 
     @route()
-    def report_download(self, data, context=None, token=None):
+    def report_download(self, data, context=None, token=None, readonly=True):
         requestcontent = json.loads(data)
         url, report_type = requestcontent[0], requestcontent[1]
         reportname = "???"
         if report_type != "qweb-xml":
-            return super().report_download(data, context=context, token=token)
+            return super().report_download(
+                data, context, token=token, readonly=readonly
+            )
         try:
             reportname = url.split("/report/xml/")[1].split("?")[0]
             docids = None


### PR DESCRIPTION
* report_py3o, report_xlsx, report_xml

odoo core introduced an additional argument in [1] to the method
inherited by report_py3o, report_xlsx, report_xml.
When the same method is inherited in other addons,
it raises a "TypeError: ... takes X positional arguments
but Y were given" due to a mismatch in the argument count.

This commit updates the mentioned method signature to match the
latest odoo core definition, ensuring compatibility and preventing
runtime errors when multiple addons override the same function.

No functional changes are introduced. Only method signatures have
been synchronized with upstream Odoo

1. https://github.com/odoo/odoo/commit/fc9e0160cebd5646035a3df47cb0c20edd9f55a4