### PR TITLE
[18.0][FIX] report_xlsx 

### DIFF
--- a/report_xlsx/static/src/js/report/action_manager_report.esm.js
+++ b/report_xlsx/static/src/js/report/action_manager_report.esm.js
@@ -8,14 +8,8 @@ registry
         if (action.report_type === "xlsx") {
             const type = action.report_type;
             let url = `/report/${type}/${action.report_name}`;
-            for (const key_data in action.data) {
-                action.context[key_data] = action.data[key_data];
-            }
             const actionContext = action.context || {};
             if (action.data && JSON.stringify(action.data) !== "{}") {
-                if (!url.includes(`/${actionContext.active_id}`)) {
-                    url += `/${actionContext.active_id}`;
-                }
                 // Build a query string with `action.data` (it's the place where reports
                 // using a wizard to customize the output traditionally put their options)
                 const action_options = encodeURIComponent(JSON.stringify(action.data));
@@ -36,7 +30,7 @@ registry
                     url: "/report/download",
                     data: {
                         data: JSON.stringify([url, action.report_type]),
-                        context: JSON.stringify(actionContext),
+                        context: JSON.stringify(user.context),
                     },
                 });
             } finally {


### PR DESCRIPTION
PR to Revert: #1057

Error to solve:

RPC_ERROR

Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/src/oca/reporting-engine/report_xlsx/controllers/main.py", line 65, in report_download
    response = self.report_routes(

..........

  File "/opt/odoo/src/oca/account-financial-reporting/account_financial_report/report/abstract_report.py", line 167, in _get_report_values
    wizard = self.env[data["wizard_name"]].browse(data["wizard_id"])
KeyError: 'wizard_name'

        
        
The core issue is that the new JavaScript code introduced a bug: while attempting to fix context propagation for XLSX reports, it broke the standard method for passing wizard data (wizard_name, wizard_id). The old JS correctly serialized the essential action.data into the URL as an option query parameter, which the OCA backend modules rely on to find the wizard instance and generate the report.