### PR TITLE
[FIX] report_layout_config: fix Spanish translations css error

### DIFF
--- a/report_layout_config/i18n/es.po
+++ b/report_layout_config/i18n/es.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* report_layout_config
+#   * report_layout_config
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: 2024-03-27 20:35+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
+"Last-Translator: Daruma IT <admin@darumait.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -15,177 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.17\n"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-"!important;\n"
-"                            }\n"
-"                        }\n"
-"                        tbody {\n"
-"                            tr:last-child td {\n"
-"                                border-bottom: 3px solid"
-msgstr ""
-"Importante;\n"
-" }\n"
-" }\n"
-" tbody {\n"
-" tr:last-child td {\n"
-" border-bottom: 3px sólido"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-"&amp;.o_clean_footer {\n"
-"                        border-top: 3px solid"
-msgstr ""
-"&amp;.o_clean_footer {\n"
-" borde superior: 3px sólido"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-"&amp;.o_report_layout_standard {\n"
-"                    h2 {\n"
-"                        color:"
-msgstr ""
-"&amp;.o_report_layout_standard {\n"
-" h2 {\n"
-" color:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                            background-color:"
-msgstr ""
-";\n"
-" color de fondo:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                            tr th {\n"
-"                                border-top: 3px solid"
-msgstr ""
-";\n"
-" tr th {\n"
-" borde superior: 3px sólido"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                            }\n"
-"                        }\n"
-"                    }\n"
-"                    #total {\n"
-"                        strong {\n"
-"                            color:"
-msgstr ""
-";\n"
-"                            }\n"
-"                        }\n"
-"                    }\n"
-"                    #total {\n"
-"                        strong {\n"
-"                            color:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                        h4 {\n"
-"                            color:"
-msgstr ""
-";\n"
-"                        h4 {\n"
-"                            color:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                        }\n"
-"                        .pagenumber {\n"
-"                            border: 3px solid"
-msgstr ""
-";\n"
-"                        }\n"
-"                        .pagenumber {\n"
-"                            border: 3px solid"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                        }\n"
-"                    }\n"
-"                &amp;.o_report_layout_clean {\n"
-"                    h1, h2, h3 {\n"
-"                        color:"
-msgstr ""
-";\n"
-"                        }\n"
-"                    }\n"
-"                &amp;.o_report_layout_clean {\n"
-"                    h1, h2, h3 {\n"
-"                        color:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                    }\n"
-"                    #informations strong {\n"
-"                        color:"
-msgstr ""
-";\n"
-"                    }\n"
-"                    #informations strong {\n"
-"                        color:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                    }\n"
-"                    #total strong{\n"
-"                        color:"
-msgstr ""
-";\n"
-"                    }\n"
-"                    #total strong{\n"
-"                        color:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                    }\n"
-"                    strong {\n"
-"                        color:"
-msgstr ""
-";\n"
-"                    }\n"
-"                    strong {\n"
-"                        color:"
-
-#. module: report_layout_config
-#: model_terms:ir.ui.view,arch_db:report_layout_config.styles_company_report
-msgid ""
-";\n"
-"                    }\n"
-"                    table {\n"
-"                        thead {\n"
-"                            color:"
-msgstr ""
-";\n"
-"                    }\n"
-"                    table {\n"
-"                        thead {\n"
-"                            color:"
 
 #. module: report_layout_config
 #: model:ir.model,name:report_layout_config.model_res_company
@@ -230,8 +59,7 @@ msgstr "Página: <span class=\"page\"/> / <span class=\"topage\"/>"
 #. module: report_layout_config
 #: model:ir.model.fields,help:report_layout_config.field_base_document_layout__full_footer_img
 msgid "Replaces whole footer, disables footer logo"
-msgstr ""
-"Sustituye todo el pie de página, desactiva el logotipo del pie de página"
+msgstr "Sustituye todo el pie de página, desactiva el logotipo del pie de página"
 
 #. module: report_layout_config
 #: model:ir.model.fields,help:report_layout_config.field_base_document_layout__full_header_img
@@ -241,12 +69,12 @@ msgstr "Sustituye toda la cabecera por una imagen"
 #. module: report_layout_config
 #: model:ir.model.fields,help:report_layout_config.field_res_company__full_footer_img
 msgid "This image will replace all footer."
-msgstr "Sustituye toda la cabecera por una imagen"
+msgstr "Sustituye todo el pie de página."
 
 #. module: report_layout_config
 #: model:ir.model.fields,help:report_layout_config.field_res_company__full_header_img
 msgid "This image will replace all header."
-msgstr "Esta imagen sustituirá a todos los encabezados."
+msgstr "Esta imagen sustituirá toda la cabecera."
 
 #~ msgid "Display Name"
 #~ msgstr "Mostrar Nombre"


### PR DESCRIPTION
This PR fixes issues in the Spanish translation file of the report_layout_config module by removing invalid CSS strings that were incorrectly included and translated, which caused styling errors in printed reports, correcting several inaccurate help-text translations related to header and footer replacement, updating translator metadata to Daruma IT, and improving minor formatting in the file. These changes ensure that report CSS renders correctly, translations are accurate, and the module behaves consistently in Spanish environments.