### PR TITLE
[IMP] sql_export_mail: allow partners as email recipients

### DIFF
--- a/sql_export_mail/models/sql_export.py
+++ b/sql_export_mail/models/sql_export.py
@@ -19,6 +19,14 @@ class SqlExport(models.Model):
         help="Add the users who want to receive the report by e-mail. You "
         "need to link the sql query with a cron to send mail automatically",
     )
+    mail_partner_ids = fields.Many2many(
+        "res.partner",
+        "mail_partner_sqlquery_rel",
+        "sql_id",
+        "partner_id",
+        help="Add the partners who wants to receive the report by e-mail. You "
+        "need to link the sql query with a cron to send a mail automatically",
+    )
     cron_ids = fields.Many2many(
         "ir.cron",
         "cron_sqlquery_rel",
@@ -136,13 +144,43 @@ class SqlExport(models.Model):
                 if not user.email:
                     raise UserError(_("The user does not have any e-mail address."))
 
+    @api.constrains("mail_partner_ids", "query")
+    def _check_mail_partner(self):
+        for export in self:
+            if export.mail_partner_ids and (
+                "%(company_id)s" in export.query or "%(user_id)s" in export.query
+            ):
+                raise UserError(
+                    _(
+                        "A query that uses the company_id or user_id parameter "
+                        "cannot be directly sent to a partner."
+                    )
+                )
+            missing_email_partners = export.mail_partner_ids.filtered(
+                lambda partner: not partner.email
+            )
+            if missing_email_partners:
+                raise UserError(
+                    _(
+                        "Missing email address for partner(s): %(names)s",
+                        names=", ".join(missing_email_partners.mapped("name")),
+                    )
+                )
+
     def get_email_address_for_template(self):
         """
-        Called from mail template
+        Called from mail template.
+        Collects email addresses from both users and partners.
         """
         self.ensure_one()
         if self.env.context.get("mail_to"):
             mail_users = self.env["res.users"].browse(self.env.context.get("mail_to"))
+            mail_partners = self.env["res.partner"]
         else:
             mail_users = self.mail_user_ids
-        return ",".join([x.email for x in mail_users if x.email])
+            mail_partners = self.mail_partner_ids
+        email_addresses = set(
+            mail_users.mapped("email") + mail_partners.mapped("email")
+        )
+        email_addresses.discard(False)
+        return ",".join(email_addresses)

--- a/sql_export_mail/tests/test_sql_query_mail.py
+++ b/sql_export_mail/tests/test_sql_query_mail.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import SUPERUSER_ID, Command
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
@@ -14,16 +15,70 @@ class TestExportSqlQueryMail(TransactionCase):
         cls.sql_report_demo.mail_user_ids = [Command.link(SUPERUSER_ID)]
 
     def test_sql_query_mail(self):
-        mail_obj = self.env["mail.mail"]
-        mails = mail_obj.search(
+        """Check the general execution"""
+        self.check_before_change()
+        self.check_execution()
+
+    def test_not_able_add_user(self):
+        """if there are field_ids, mail_user_ids can not be set"""
+        sql_report_demo_with_partner = self.env.ref(
+            "sql_export.sql_export_partner_with_variables"
+        )
+        with self.assertRaises(UserError):
+            sql_report_demo_with_partner.write(
+                {"mail_user_ids": [(4, self.env.ref("base.user_demo").id)]}
+            )
+
+    def test_sql_query_mail_company(self):
+        """Check the general execution with %(company_id)s"""
+        self.check_before_change()
+        self.sql_report_demo.write(
+            {
+                "mail_user_ids": [(4, self.env.ref("base.user_demo").id)],
+                "query": """SELECT name, street
+                                    FROM res_partner
+                                     where company_id = %(company_id)s""",
+            }
+        )
+        self.check_execution()
+
+    def test_sql_query_mail_company_user(self):
+        """Check the general execution with %(company_id)s and %(user_id)s)"""
+        self.check_before_change()
+        self.sql_report_demo.write(
+            {
+                "mail_user_ids": [(4, self.env.ref("base.user_demo").id)],
+                "query": """SELECT name, street FROM res_partner
+                                    where company_id = %(company_id)s and id in (
+                                    select partner_id
+                                    from res_users where id = %(user_id)s)""",
+            }
+        )
+        self.check_execution()
+
+    def test_sql_query_mail_partner(self):
+        """Check if emails are sent to partners"""
+        self.check_before_change()
+        partner = self.env.ref("base.res_partner_2")
+        self.sql_report_demo.write({"mail_partner_ids": [(4, partner.id)]})
+        self.check_execution(partner)
+
+    def check_before_change(self):
+        """Check if there are no mails before changing the sql report"""
+        mails = self.env["mail.mail"].search(
             [("model", "=", "sql.export"), ("res_id", "=", self.sql_report_demo.id)]
         )
         self.assertFalse(mails)
+
+    def check_execution(self, partner=None):
+        """Check if the cron could be created and the mail sending is working"""
         self.sql_report_demo.create_cron()
         self.assertTrue(self.sql_report_demo.cron_ids)
         self.sql_report_demo.cron_ids.method_direct_trigger()
-        mails = mail_obj.search(
+        mails = self.env["mail.mail"].search(
             [("model", "=", "sql.export"), ("res_id", "=", self.sql_report_demo.id)]
         )
         self.assertTrue(mails)
         self.assertTrue(mails.attachment_ids)
+        if partner:
+            self.assertIn(partner.email, mails.mapped("email_to"))

--- a/sql_export_mail/views/sql_export_view.xml
+++ b/sql_export_mail/views/sql_export_view.xml
@@ -21,22 +21,30 @@
             </field>
             <page name="page_sql" position="after">
                 <page name="page_mail" string="Mail">
-                        <group string="Users Notified by e-mail">
-                            <field
+                    <group string="Users Notified by e-mail">
+                        <field
                             name="mail_user_ids"
                             nolabel="1"
                             widget="many2many_tags"
                             colspan="2"
                         />
-                        </group>
-                        <group string="Crons" groups="base.group_system">
-                            <field
+                    </group>
+                    <group string="Partners Notified by e-mail">
+                        <field
+                            name="mail_partner_ids"
+                            nolabel="1"
+                            widget="many2many_tags"
+                            colspan="2"
+                        />
+                    </group>
+                    <group string="Crons" groups="base.group_system">
+                        <field
                             name="cron_ids"
                             nolabel="1"
                             colspan="2"
                             domain="[('model_id', '=', 'sql.export')]"
                         />
-                        </group>
+                    </group>
                 </page>
             </page>
         </field>


### PR DESCRIPTION
## What does this PR do?
Add a **backported feature** for sending SQL export reports to partners in addition to users. This enables more flexible notification workflows by allowing partners to receive automated reports via email.

## Migration Notes
This feature is backported from v18/16 to v17 so it already existed.

## Testing
All pre-commit hooks passed including:
- ✅ Ruff (Python linting)
- ✅ Pylint-odoo (mandatory checks)
- ✅ OCA module structure checks
- ✅ XML validation

Unit tests:
- ✅ test_sql_query_mail_partner (new)
- ✅ All existing tests still pass

Manual testing performed with partner email notifications.