### PR TITLE
[18.0][FIX] report_csv: add None check for docids in _render_csv

### DIFF
--- a/report_csv/README.rst
+++ b/report_csv/README.rst
@@ -128,6 +128,10 @@ Contributors
 
   - Aung Ko Ko Lin
 
+- `NuoBiT <https://www.nuobit.com>`__:
+
+  - Deniz Gallo dgallo@nuobit.com
+
 Maintainers
 -----------
 

--- a/report_csv/models/ir_report.py
+++ b/report_csv/models/ir_report.py
@@ -55,7 +55,7 @@ class ReportAction(models.Model):
         report_sudo = self._get_report(report_ref)
         report_model_name = f"report.{report_sudo.report_name}"
         report_model = self.env[report_model_name]
-        res_id = len(docids) == 1 and docids[0]
+        res_id = docids and len(docids) == 1 and docids[0]
         if not res_id or not report_sudo.attachment or not report_sudo.attachment_use:
             return report_model.with_context(
                 **{

--- a/report_csv/readme/CONTRIBUTORS.md
+++ b/report_csv/readme/CONTRIBUTORS.md
@@ -3,3 +3,5 @@
 - Rattapong Chokmasermkul \<<rattapongc@ecosoft.co.th>\>
 - [Quartile](https://www.quartile.co):
   - Aung Ko Ko Lin
+- [NuoBiT](https://www.nuobit.com):
+  - Deniz Gallo <dgallo@nuobit.com>

--- a/report_csv/static/description/index.html
+++ b/report_csv/static/description/index.html
@@ -471,6 +471,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Aung Ko Ko Lin</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.nuobit.com">NuoBiT</a>:<ul>
+<li>Deniz Gallo <a class="reference external" href="mailto:dgallo&#64;nuobit.com">dgallo&#64;nuobit.com</a></li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
It is being assumed that the parameter docids is always iterable, and len(docids) is called without validation, which therefore raises an error.