### PR TITLE
[17.0][FIX]kpi_views: Fix typo of group to groups

### DIFF
--- a/kpi/views/kpi_views.xml
+++ b/kpi/views/kpi_views.xml
@@ -72,7 +72,7 @@
                     <separator orientation="vertical" />
                     <field name="name" />
                     <field name="category_id" />
-                    <field name="company_id" group="base.group_multi_company" />
+                    <field name="company_id" groups="base.group_multi_company" />
                 </group>
                 <newline />
                 <group expand="0" name="Group By...">


### PR DESCRIPTION
    Fix typo of group to groups in kpi_views.xml.
    This was causing the warning:
    "attribute 'group' is not valid.
    Did you mean 'groups'?"