### PR TITLE
[18.0][FIX] report_csv: prevent crash when docids is None in _render_csv

### DIFF
--- a/report_csv/models/ir_report.py
+++ b/report_csv/models/ir_report.py
@@ -55,7 +55,7 @@ class ReportAction(models.Model):
         report_sudo = self._get_report(report_ref)
         report_model_name = f"report.{report_sudo.report_name}"
         report_model = self.env[report_model_name]
-        res_id = len(docids) == 1 and docids[0]
+        res_id = docids and len(docids) == 1 and docids[0]
         if not res_id or not report_sudo.attachment or not report_sudo.attachment_use:
             return report_model.with_context(
                 **{


### PR DESCRIPTION
Fixes #1125 

Add a defensive check in `_render_csv` to avoid calling `len()` on `None`
when `docids` is not provided.

This aligns CSV report rendering with other Odoo report renderers
and prevents a `TypeError`.