### PR TITLE
[19.0][MIG] bi_sql_editor: Prevent failure if default parent menu is not loaded.

### DIFF
--- a/bi_sql_editor/README.rst
+++ b/bi_sql_editor/README.rst
@@ -182,6 +182,8 @@ Contributors
 
 - Thien Vo thienvh@trobz.com
 
+- Baptiste P. baptiste@newlogic.com
+
 - This module is highly inspired by the work of
 
   - Onestein: (http://www.onestein.nl/) Module:

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -116,7 +116,9 @@ class BiSQLView(models.Model):
 
     @api.model
     def _default_parent_menu_id(self):
-        return self.env.ref("bi_sql_editor.menu_bi_sql_editor")
+        return self.env.ref(
+            "bi_sql_editor.menu_bi_sql_editor", raise_if_not_found=False
+        )
 
     parent_menu_id = fields.Many2one(
         string="Parent Odoo Menu",

--- a/bi_sql_editor/readme/CONTRIBUTORS.md
+++ b/bi_sql_editor/readme/CONTRIBUTORS.md
@@ -8,6 +8,8 @@
 
 - Thien Vo <thienvh@trobz.com>
 
+- Baptiste P. <baptiste@newlogic.com>
+
 - This module is highly inspired by the work of
   - Onestein: (<http://www.onestein.nl/>) Module:
     OCA/server-tools/bi_view_editor. Link:

--- a/bi_sql_editor/static/description/index.html
+++ b/bi_sql_editor/static/description/index.html
@@ -510,6 +510,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>David James, WilldooIT (<a class="reference external" href="http://www.willdooit.com/">http://www.willdooit.com/</a>)</li>
 <li>Guillem Casassas <a class="reference external" href="mailto:guillem.casassas&#64;forgeflow.com">guillem.casassas&#64;forgeflow.com</a></li>
 <li>Thien Vo <a class="reference external" href="mailto:thienvh&#64;trobz.com">thienvh&#64;trobz.com</a></li>
+<li>Baptiste P. <a class="reference external" href="mailto:baptiste&#64;newlogic.com">baptiste&#64;newlogic.com</a></li>
 <li>This module is highly inspired by the work of<ul>
 <li>Onestein: (<a class="reference external" href="http://www.onestein.nl/">http://www.onestein.nl/</a>) Module:
 OCA/server-tools/bi_view_editor. Link:


### PR DESCRIPTION
 Issue occurs when upgrading from an old version of this module.

`ValueError: External ID not found in the system: bi_sql_editor.menu_bi_sql_editor`