### PR TITLE
[FIX] report_py3o: make div container role alert conditionally invisible

### DIFF
--- a/report_py3o/views/ir_actions_report.xml
+++ b/report_py3o/views/ir_actions_report.xml
@@ -8,11 +8,13 @@
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="before">
                 <field name="is_py3o_report_not_available" invisible="1" />
-                <div class="alert alert-danger" role="alert" style="margin-bottom:0px;">
-                    <field
-                        name="msg_py3o_report_not_available"
-                        invisible="not is_py3o_report_not_available"
-                    />
+                <div
+                    class="alert alert-danger"
+                    role="alert"
+                    style="margin-bottom:0px;"
+                    invisible="not is_py3o_report_not_available"
+                >
+                    <field name="msg_py3o_report_not_available" />
                 </div>
             </xpath>
             <xpath expr="//page[@name='security']" position="before">


### PR DESCRIPTION
This is PR fix this:

<img width="1529" height="465" alt="image" src="https://github.com/user-attachments/assets/92f91c50-a22c-46d0-95c6-2b298d6b85f4" />

@BinhexTeam T18741