### PR TITLE
[18.0][FIX] base_comment_template: fix tests

### DIFF
--- a/base_comment_template/tests/test_base_comment_template.py
+++ b/base_comment_template/tests/test_base_comment_template.py
@@ -14,6 +14,13 @@ class TestCommentTemplate(common.TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         setup_test_model(cls.env, ResUsers)
+        res_users_model = cls.env.registry["res.users"]
+        # Register the comment_template_ids field added by comment.template mixin
+        cls.classPatch(
+            res_users_model,
+            "comment_template_ids",
+            res_users_model.comment_template_ids,
+        )
         cls.user_obj = cls.env.ref("base.model_res_users")
         cls.user = cls.env.ref("base.user_demo")
         cls.user2 = cls.env.ref("base.demo_user0")


### PR DESCRIPTION
Odoo 18 introduced stricter test validation (https://github.com/odoo/odoo/commit/de056cc#diff-80aef099e5fb41cc09e699d35b749152aca50caf5b0bc16c400081c29023fbec) that checks for unexpected attributes added to models during tests. Our tests extend the existing `res.users` model with the `comment.template` mixin, which adds `comment_template_ids` and causes `AssertionError: Found unexpected attributes on res.users: comment_template_ids`.

I fixed by registering the mixin attribute using `classPatch()`. If anyone has a cleaner solution, suggestions are welcome!

@qrtl QT6451