### PR TITLE
[18.0][FIX] report_csv: self is model cls here - must use report_sudo for encoding and encode_error_handling

### DIFF
--- a/report_csv/models/ir_report.py
+++ b/report_csv/models/ir_report.py
@@ -60,8 +60,8 @@ class ReportAction(models.Model):
             return report_model.with_context(
                 **{
                     "active_model": report_sudo.model,
-                    "encoding": self.encoding,
-                    "encode_error_handling": self.encode_error_handling,
+                    "encoding": report_sudo.encoding,
+                    "encode_error_handling": report_sudo.encode_error_handling,
                 }
             ).create_csv_report(docids, data)
         record = self.env[report_sudo.model].browse(res_id)
@@ -71,8 +71,8 @@ class ReportAction(models.Model):
         data, ext = report_model.with_context(
             **{
                 "active_model": report_sudo.model,
-                "encoding": self.encoding,
-                "encode_error_handling": self.encode_error_handling,
+                "encoding": report_sudo.encoding,
+                "encode_error_handling": report_sudo.encode_error_handling,
             }
         ).create_csv_report(docids, data)
         report_sudo._create_csv_attachment(record, data)


### PR DESCRIPTION
Problem got visible as soon as i tried to use such a report within a mail.template. mail.template likes binary attachment, so i did set an encoding. But got the same error, so i found this bug...