### PR TITLE
[FIX] report_csv: guard docids against None in _render_csv

### DIFF
--- a/report_csv/models/ir_report.py
+++ b/report_csv/models/ir_report.py
@@ -55,7 +55,7 @@ class ReportAction(models.Model):
         report_sudo = self._get_report(report_ref)
         report_model_name = f"report.{report_sudo.report_name}"
         report_model = self.env[report_model_name]
-        res_id = docids[0] if docids and len(docids) == 1 else None
+        res_id = docids[0] if docids else None
         if not res_id or not report_sudo.attachment or not report_sudo.attachment_use:
             return report_model.with_context(
                 **{


### PR DESCRIPTION
[FIX] report_csv: guard docids against None in _render_csv

The _render_csv method called len(docids) without checking if docids
is None, causing a TypeError when rendering CSV reports without
passing record IDs (e.g., from the UI wizard).

Forward-port of the fix needed for 18.0 as reported in #1125.

Fixes #1125