### PR TITLE
[18.0][IMP] report_py3o: improve error observability in LO conversion chain

### DIFF
--- a/report_py3o/controllers/main.py
+++ b/report_py3o/controllers/main.py
@@ -1,6 +1,7 @@
 # Copyright 2017 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 import json
+import logging
 import mimetypes
 from urllib.parse import parse_qs
 
@@ -11,6 +12,8 @@ from odoo.http import content_disposition, request, route, serialize_exception
 from odoo.tools import html_escape
 
 from odoo.addons.web.controllers.report import ReportController as ReportControllerBase
+
+logger = logging.getLogger(__name__)
 
 
 class ReportController(ReportControllerBase):
@@ -41,8 +44,7 @@ class ReportController(ReportControllerBase):
         ).with_context(**context)
         if not action_py3o_report:
             raise exceptions.HTTPException(
-                description="Py3o action report not found for report_name "
-                f"{reportname}"
+                description=f"Py3o action report not found for report_name {reportname}"
             )
         res, filetype = ir_action._render(reportname, docids, data)
         filename = action_py3o_report.gen_report_download_filename(docids, data)
@@ -92,6 +94,7 @@ class ReportController(ReportControllerBase):
             response.set_cookie("fileToken", context)
             return response
         except Exception as e:
+            logger.exception("Error while generating py3o report: %s", reportname)
             se = serialize_exception(e)
             error = {"code": 200, "message": "Odoo Server Error", "data": se}
             return request.make_response(html_escape(json.dumps(error)))

--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -15,7 +15,7 @@ from io import BytesIO
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from odoo import _, api, fields, models, tools
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tools.safe_eval import safe_eval, time
 
 from ._py3o_parser_context import Py3oParserContext
@@ -98,7 +98,7 @@ class Py3oReport(models.TransientModel):
         is_valid = real_path.startswith(root_path + os.path.sep)
         if not is_valid:
             logger.warning(
-                "Py3o template path is not valid. %s is not a child of root " "path %s",
+                "Py3o template path is not valid. %s is not a child of root path %s",
                 real_path,
                 root_path,
             )
@@ -262,9 +262,35 @@ class Py3oReport(models.TransientModel):
                     user_installation=tmp_user_installation,
                 )
                 logger.debug("Running command %s", command)
-                output = subprocess.check_output(
-                    command, cwd=os.path.dirname(result_path)
-                )
+                try:
+                    output = subprocess.check_output(
+                        command,
+                        cwd=os.path.dirname(result_path),
+                        stderr=subprocess.STDOUT,
+                    )
+                except FileNotFoundError:
+                    raise UserError(
+                        _(
+                            "LibreOffice binary not found: %s.\n"
+                            "Please check the py3o conversion command "
+                            "configuration."
+                        )
+                        % command[0]
+                    ) from None
+                except subprocess.CalledProcessError as exc:
+                    logger.error(
+                        "LibreOffice conversion failed.\n"
+                        "Exit code: %d\nCommand: %s\nOutput: %s",
+                        exc.returncode,
+                        " ".join(command),
+                        exc.output.decode("utf-8", errors="replace"),
+                    )
+                    raise UserError(
+                        _(
+                            "The report could not be generated. "
+                            "Please contact your administrator."
+                        )
+                    ) from exc
                 logger.debug("Output was %s", output)
                 self._cleanup_tempfiles([result_path])
                 result_path, result_filename = os.path.split(result_path)
@@ -272,6 +298,20 @@ class Py3oReport(models.TransientModel):
                     result_path,
                     f"{os.path.splitext(result_filename)[0]}.{self.ir_actions_report_id.py3o_filetype}",
                 )
+                if not os.path.exists(result_path):
+                    logger.error(
+                        "LibreOffice reported success but output file not found: %s.\n"
+                        "Stderr output: %s",
+                        result_path,
+                        output.decode("utf-8", errors="replace")[-2000:],
+                    )
+                    raise UserError(
+                        _(
+                            "The report could not be generated. "
+                            "The template may contain unsupported content. "
+                            "Please contact your administrator."
+                        )
+                    )
         return result_path
 
     def _convert_single_report_cmd(
@@ -280,7 +320,7 @@ class Py3oReport(models.TransientModel):
         """Return a command list suitable for use in subprocess.call"""
         lo_bin = self.ir_actions_report_id.lo_bin_path
         if not lo_bin:
-            raise RuntimeError(
+            raise UserError(
                 _(
                     "Libreoffice runtime not available. "
                     "Please contact your administrator."

--- a/report_py3o/tests/test_report_py3o.py
+++ b/report_py3o/tests/test_report_py3o.py
@@ -5,6 +5,7 @@ import base64
 import logging
 import os
 import shutil
+import subprocess
 import tempfile
 from base64 import b64decode, b64encode
 from contextlib import contextmanager
@@ -20,11 +21,15 @@ except ImportError:
     # For PyPDF2 >= 2.0.0
     from PyPDF2 import PageObject
 
-from odoo import tools
-from odoo.exceptions import ValidationError
+import json
+
+from odoo import http, tools
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import common
 from odoo.tests.common import TransactionCase
 
 from odoo.addons.base.tests.test_mimetypes import PNG
+from odoo.addons.report_py3o.controllers.main import ReportController
 
 from ..models._py3o_parser_context import format_multiline_value
 from ..models.ir_actions_report import PY3O_CONVERSION_COMMAND_PARAMETER
@@ -75,9 +80,8 @@ class TestReportPy3o(TransactionCase):
             result = tempfile.mktemp(".txt")
             with open(result, "w") as fp:
                 fp.write(result_text)
-            patched_pdf.side_effect = (
-                lambda record, data: py3o_report_obj._postprocess_report(record, result)
-                or result
+            patched_pdf.side_effect = lambda record, data: (
+                py3o_report_obj._postprocess_report(record, result) or result
             )
             # test the call the the create method inside our custom parser
             self.report._render(self.report.id, self.env.user.ids)
@@ -252,7 +256,7 @@ class TestReportPy3o(TransactionCase):
         self.assertFalse(self.report.is_py3o_native_format)
         self.assertTrue(self.report.is_py3o_report_not_available)
         self.assertTrue(self.report.msg_py3o_report_not_available)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(UserError):
             self.report._render(self.report.id, self.env.user.ids)
 
         # if we reset the wrong path, everything should work
@@ -266,3 +270,53 @@ class TestReportPy3o(TransactionCase):
         self.assertFalse(self.report.msg_py3o_report_not_available)
         res = self.report._render(self.report.id, self.env.user.ids)
         self.assertTrue(res)
+
+    @tools.misc.mute_logger("odoo.addons.report_py3o.models.py3o_report")
+    def test_convert_single_report_called_process_error(self):
+        self.report.py3o_filetype = "pdf"
+        py3o_report = self.env["py3o.report"].create(
+            {"ir_actions_report_id": self.report.id}
+        )
+        result_path = tempfile.mkstemp(suffix=".odt")[1]
+        self.addCleanup(os.unlink, result_path)
+        with mock.patch("subprocess.check_output") as mock_co:
+            mock_co.side_effect = subprocess.CalledProcessError(
+                returncode=1, cmd="libreoffice", output=b"test error output"
+            )
+            with self.assertRaises(UserError):
+                py3o_report._convert_single_report(result_path, self.env.user, {})
+
+
+class TestReportPy3oController(common.HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.session = self.authenticate("admin", "admin")
+
+    @tools.misc.mute_logger("odoo.addons.web.controllers.report")
+    def test_report_download_error_logging(self):
+        with (
+            mock.patch.object(ReportController, "report_routes") as route_patch,
+            self.assertLogs(
+                "odoo.addons.report_py3o.controllers.main", level=logging.ERROR
+            ) as cm,
+        ):
+            route_patch.side_effect = Exception("Test error")
+            self.get_report_headers(
+                suffix="/report/py3o/report_py3o.res_users_report_py3o/1",
+                f_type="py3o",
+            )
+            [msg] = cm.output
+            self.assertIn("Error while generating py3o report", msg)
+
+    def get_report_headers(
+        self,
+        suffix="/report/py3o/report_py3o.res_users_report_py3o/1",
+        f_type="py3o",
+    ):
+        return self.url_open(
+            url="/report/download",
+            data={
+                "data": json.dumps([suffix, f_type]),
+                "csrf_token": http.Request.csrf_token(self),
+            },
+        )


### PR DESCRIPTION
### Problem

When LibreOffice fails to convert a rendered ODT to the target format, `FileNotFoundError` propagates unhandled, the controller catches it without logging, and debugging is impossible.

**Actual production traceback** (anonymized):

```
  File ".../reporting-engine/report_py3o/controllers/main.py", line 82, in report_download
    response = self.report_routes(
  File ".../odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File ".../reporting-engine/report_xml/controllers/report.py", line 24, in report_routes
    return super().report_routes(
  File ".../odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File ".../reporting-engine/report_xlsx_helper/controllers/main.py", line 51, in report_routes
    return super().report_routes(reportname, docids, converter, **data)
  File ".../odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File ".../reporting-engine/report_xlsx/controllers/main.py", line 51, in report_routes
    return super().report_routes(reportname, docids, converter, **data)
  File ".../odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File ".../reporting-engine/report_py3o/controllers/main.py", line 47, in report_routes
    res, filetype = ir_action._render(reportname, docids, data)
  File ".../odoo/addons/base/models/ir_actions_report.py", line 1135, in _render
    return render_func(report_ref, res_ids, data=data)
  File ".../reporting-engine/report_py3o/models/ir_actions_report.py", line 171, in _render_py3o
    .create_report(res_ids, data)
  File ".../reporting-engine/report_py3o/models/py3o_report.py", line 394, in create_report
    with open(result_path, "r+b") as fd:

FileNotFoundError: [Errno 2] No such file or directory:
    '/tmp/p3o.report.tmp.xxxxxxxx.pdf'
```

**The `FileNotFoundError` is not the root cause** — it is the last symptom of a silent failure chain:

1. LibreOffice runs `--headless --convert-to` → **exit code 0** → but silently produces no output file (e.g. because the rendered ODT contains HTML content LO cannot handle)
2. `_convert_single_report` has **zero error handling** — `subprocess.check_output` succeeds, code computes the expected output path, never verifies the file exists
3. `create_report` tries `open(result_path, "r+b")` → **`FileNotFoundError`** propagates
4. Controller's `except Exception` **does not log** — the entire traceback is silently swallowed, returned as JSON to the browser, and lost on page refresh

### Fix

Two minimal changes following OCA patterns already used by sibling addons (`report_csv`, `report_xlsx`, `report_xml`):

**`py3o_report.py` — Model-level error handling:**
- Capture LO stderr: `subprocess.check_output(..., stderr=subprocess.STDOUT)`
- `try/except FileNotFoundError` → `UserError`
- `try/except CalledProcessError` → `logger.error(details)` + `UserError`
- Post-conversion: `os.path.exists(result_path)` → `logger.error(stderr)` + `UserError` if missing
- `_convert_single_report_cmd`: `RuntimeError` → `UserError`

**`controllers/main.py` — Controller-level logging (one line):**
- `logger.exception("Error while generating py3o report: %s", reportname)` before `serialize_exception`
- Matches `report_csv`, `report_xlsx`, `report_xml` controllers exactly

### Testing

Two new tests added:

| Test | Pattern | Verifies |
|---|---|---|
| `test_convert_single_report_called_process_error` | `TransactionCase` + `mock.patch("subprocess.check_output")` | `_convert_single_report` raises `UserError` on LO failure |
| `TestReportPy3oController.test_report_download_error_logging` | `HttpCase` + `mock.patch.object(ReportController, "report_routes")` + `assertLogs` | Controller logs before serializing error JSON |

@BinhexTeam T18747