### PR TITLE
[19.0][FIX] base_comment_template: comment_template_ids domain

### DIFF
--- a/base_comment_template/models/comment_template.py
+++ b/base_comment_template/models/comment_template.py
@@ -26,7 +26,9 @@ class CommentTemplate(models.AbstractModel):
         compute_sudo=True,
         comodel_name="base.comment.template",
         string="Comment Template",
-        domain=lambda self: [("model_ids", "in", self._name)],
+        domain=lambda self: self.env["base.comment.template"]._search_model_ids(
+            "in", self._name
+        ),
         store=True,
         readonly=False,
     )


### PR DESCRIPTION
The field filtered candidates by comparing the computed, non-stored relational field  against a model name string:

    domain=lambda self: [(model_ids, in, self._name)]

The 19.0 domain engine (odoo.fields.Domain) rewrites a relational-vs- scalar leaf into the operator with a sub-domain on the comodel:

    (model_ids, any, [(display_name, in, [account.asset])])
    
 This matches `ir.model.display_name` (a translatable label eg. "Asset/Revenue Recognition"), never the
technical name, so it resolves to no records and the templates are
filtered out on inheriting models.

Build the domain from _search_model_ids instead.