### PR TITLE
[18.0] [FIX] report_pdf_form: handle also report id as report_ref

### DIFF
--- a/report_pdf_form/models/ir_actions_report.py
+++ b/report_pdf_form/models/ir_actions_report.py
@@ -23,10 +23,12 @@ class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
 
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):
-        pdf_form_report = self.env["report.pdf.form"].search(
-            [("report_name", "=", report_ref)]
+        ReportPdfFormSudo = self.env["report.pdf.form"].sudo()
+        report = self._get_report(report_ref)
+        pdf_form_report = ReportPdfFormSudo.search(
+            [("report_id", "=", report.id)],
+            limit=1,
         )
-
         if not pdf_form_report:
             return super()._render_qweb_pdf_prepare_streams(
                 report_ref, data, res_ids=res_ids

--- a/report_pdf_form/tests/test_report_pdf_form.py
+++ b/report_pdf_form/tests/test_report_pdf_form.py
@@ -91,7 +91,7 @@ class TestReportPDFForm(common.TransactionCase):
             res[pdf_object["/T"].split("__")[1]] = pdf_object["/V"]
         return res
 
-    def test_fill_pdf_form(self):
+    def test_fill_pdf_form_by_name(self):
         streams_dict = self.env["ir.actions.report"]._render_qweb_pdf_prepare_streams(
             "pdf_form.example", {}, res_ids=self.azure_partner.ids
         )
@@ -108,3 +108,19 @@ class TestReportPDFForm(common.TransactionCase):
                 self.assertEqual(pdf_field_value, self.azure_partner.child_ids[0].name)
             elif pdf_field_name == "form_line_2":
                 self.assertEqual(pdf_field_value, "")
+
+    def test_fill_pdf_form_by_id(self):
+        """report_ref passed as int (report id) must not raise AssertionError."""
+        streams_dict = self.env["ir.actions.report"]._render_qweb_pdf_prepare_streams(
+            self.empty_report.id, {}, res_ids=self.azure_partner.ids
+        )
+        self.assertIn(self.azure_partner.id, streams_dict)
+        self.assertIsNotNone(streams_dict[self.azure_partner.id]["stream"])
+
+    def test_fill_pdf_form_by_record(self):
+        """report_ref passed as models.Model recordset must not raise AssertionError."""
+        streams_dict = self.env["ir.actions.report"]._render_qweb_pdf_prepare_streams(
+            self.empty_report, {}, res_ids=self.azure_partner.ids
+        )
+        self.assertIn(self.azure_partner.id, streams_dict)
+        self.assertIsNotNone(streams_dict[self.azure_partner.id]["stream"])


### PR DESCRIPTION
`_render_qweb_pdf_prepare_streams` can receive `report_ref` as an int, a models.Model instance, or a str. We then can get an error like below. I suggest to cover all three cases.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 2167, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/service/model.py", line 157, in retrying
    result = func()
             ^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 2134, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 2382, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/documents_account/models/account_journal.py", line 13, in create_document_from_attachment
    action = super().create_document_from_attachment(attachment_ids)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_bank_statement_import/models/account_journal.py", line 30, in create_document_from_attachment
    return journal._import_bank_statement(attachments)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_bank_statement_extract/models/account_journal.py", line 38, in _import_bank_statement
    return super()._import_bank_statement(attachments)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_bank_statement_import_csv/models/account_journal.py", line 30, in _import_bank_statement
    return super()._import_bank_statement(attachments)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_bank_statement_import/models/account_journal.py", line 56, in _import_bank_statement
    statement_ids, dummy, notifications = self._create_bank_statements(stmts_vals)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_bank_statement_import/models/account_journal.py", line 298, in _create_bank_statements
    statement.action_generate_attachment()
  File "/home/odoo/src/enterprise/account_accountant/models/account_bank_statement.py", line 35, in action_generate_attachment
    content, _content_type = ir_actions_report_sudo._render_qweb_pdf(statement_report, res_ids=statement.ids)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 1024, in _render_qweb_pdf
    collected_streams, report_type = self._pre_render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/ir_actions_report.py", line 75, in _pre_render_qweb_pdf
    return super()._pre_render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 1015, in _pre_render_qweb_pdf
    return self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids), 'pdf'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/sale_pdf_quote_builder/models/ir_actions_report.py", line 17, in _render_qweb_pdf_prepare_streams
    result = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_followup/models/ir_actions_report.py", line 12, in _render_qweb_pdf_prepare_streams
    res = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/l10n_ch/models/ir_actions_report.py", line 35, in _render_qweb_pdf_prepare_streams
    res = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/purchase/models/ir_actions_report.py", line 12, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/hr_expense/models/ir_actions_report.py", line 12, in _render_qweb_pdf_prepare_streams
    res = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account_edi_ubl_cii/models/ir_actions_report.py", line 11, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account_edi/models/ir_actions_report.py", line 14, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/ir_actions_report.py", line 22, in _render_qweb_pdf_prepare_streams
    return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/odoo/external-src/reporting-engine/report_pdf_form/models/ir_actions_report.py", line 26, in _render_qweb_pdf_prepare_streams
    pdf_form_report = self.env["report.pdf.form"].search(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 1754, in search
    return self.search_fetch(domain, [], offset=offset, limit=limit, order=order)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 1778, in search_fetch
    query = self._search(domain, offset=offset, limit=limit, order=order or self._order)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 5818, in _search
    query = self._where_calc(domain)
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 5569, in _where_calc
    return expression.expression(domain, self).query
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/osv/expression.py", line 799, in init
    self.parse()
  File "/home/odoo/src/odoo/odoo/osv/expression.py", line 1459, in parse
    push_result(model._condition_to_sql(alias, left, operator, right, self.query))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 3155, in _condition_to_sql
    assert not isinstance(value, BaseModel), \
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Invalid value ir.actions.report(1692,) in domain term ('report_name', '=', ir.actions.report(1692,))
```