### PR TITLE
[17.0][IMP] kpi: expose dateutil and mean in safe_eval context

### DIFF
--- a/kpi/models/kpi.py
+++ b/kpi/models/kpi.py
@@ -9,7 +9,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT as DATETIME_FORMAT
-from odoo.tools.safe_eval import safe_eval
+from odoo.tools.safe_eval import dateutil, safe_eval
 
 _logger = logging.getLogger(__name__)
 
@@ -164,7 +164,8 @@ class KPI(models.Model):
                     kpi_value = res[0]["value"]
             elif self.kpi_type == "python":
                 kpi_value = safe_eval(
-                    self.kpi_code, {"self": self, "datetime": fields.datetime}
+                    self.kpi_code,
+                    {"self": self, "datetime": fields.datetime, "dateutil": dateutil},
                 )
         if isinstance(kpi_value, dict):
             res = kpi_value

--- a/kpi/models/kpi.py
+++ b/kpi/models/kpi.py
@@ -4,6 +4,7 @@
 import logging
 import re
 from datetime import datetime
+from statistics import mean
 
 from dateutil.relativedelta import relativedelta
 
@@ -165,7 +166,12 @@ class KPI(models.Model):
             elif self.kpi_type == "python":
                 kpi_value = safe_eval(
                     self.kpi_code,
-                    {"self": self, "datetime": fields.datetime, "dateutil": dateutil},
+                    {
+                        "self": self,
+                        "datetime": fields.datetime,
+                        "dateutil": dateutil,
+                        "mean": mean,
+                    },
                 )
         if isinstance(kpi_value, dict):
             res = kpi_value

--- a/kpi/tests/test_kpi.py
+++ b/kpi/tests/test_kpi.py
@@ -127,3 +127,25 @@ class TestKPI(TransactionCase):
         self.assertEqual(len(kpi_history), 1)
         self.assertEqual(kpi_history.color, "#00FF00")
         self.assertEqual(kpi_history.value, 1.0)
+
+    def test_kpi_python_dateutil(self):
+        kpi_category = self.env["kpi.category"].create({"name": "Dynamic KPIs"})
+        kpi_threshold = self.env["kpi.threshold"].create(
+            {"name": "KPI Threshold for dynamic KPIs"}
+        )
+        kpi = self.env["kpi"].create(
+            {
+                "name": "KPI with dateutil",
+                "description": "KPI using dateutil in python code",
+                "category_id": kpi_category.id,
+                "threshold_id": kpi_threshold.id,
+                "periodicity": 1,
+                "periodicity_uom": "day",
+                "kpi_type": "python",
+                "kpi_code": "dateutil.relativedelta.relativedelta(days=1).days",
+            }
+        )
+        kpi.update_kpi_value()
+        kpi_history = self.env["kpi.history"].search([("kpi_id", "=", kpi.id)])
+        self.assertEqual(len(kpi_history), 1)
+        self.assertEqual(kpi_history.value, 1.0)

--- a/kpi/tests/test_kpi.py
+++ b/kpi/tests/test_kpi.py
@@ -149,3 +149,25 @@ class TestKPI(TransactionCase):
         kpi_history = self.env["kpi.history"].search([("kpi_id", "=", kpi.id)])
         self.assertEqual(len(kpi_history), 1)
         self.assertEqual(kpi_history.value, 1.0)
+
+    def test_kpi_python_mean(self):
+        kpi_category = self.env["kpi.category"].create({"name": "Dynamic KPIs"})
+        kpi_threshold = self.env["kpi.threshold"].create(
+            {"name": "KPI Threshold for dynamic KPIs"}
+        )
+        kpi = self.env["kpi"].create(
+            {
+                "name": "KPI with mean",
+                "description": "KPI using mean in python code",
+                "category_id": kpi_category.id,
+                "threshold_id": kpi_threshold.id,
+                "periodicity": 1,
+                "periodicity_uom": "day",
+                "kpi_type": "python",
+                "kpi_code": "mean([1.0, 2.0, 3.0])",
+            }
+        )
+        kpi.update_kpi_value()
+        kpi_history = self.env["kpi.history"].search([("kpi_id", "=", kpi.id)])
+        self.assertEqual(len(kpi_history), 1)
+        self.assertEqual(kpi_history.value, 2.0)


### PR DESCRIPTION
This PR extends the Python KPI safe_eval context with two additional helpers:

- `dateutil`: useful for date arithmetic, especially `relativedelta`, in time-based KPI formulas.
- `mean`: convenience function from the `statistics` module to compute averages directly in KPI formulas.

Both are commonly needed in real-world KPI definitions and avoid requiring custom modules just to expose these utilities.

Commits:
1. [IMP] kpi: expose dateutil in safe_eval context
2. [IMP] kpi: expose mean function in safe_eval context

Includes tests for both helpers.