### PR TITLE
[17.0][IMP] kpi: add _get_eval_context hook

### DIFF
--- a/kpi/models/kpi.py
+++ b/kpi/models/kpi.py
@@ -144,6 +144,15 @@ class KPI(models.Model):
                 obj.color = "#FFFFFF"
                 obj.last_execution = False
 
+    def _get_eval_context(self):
+        """Return the evaluation context used for Python KPI expressions.
+
+        This method is meant to be extended by other modules to inject
+        additional safe globals into KPI formulas.
+        """
+        self.ensure_one()
+        return {"self": self, "datetime": fields.datetime}
+
     def _get_kpi_value(self):
         self.ensure_one()
         kpi_value = 0
@@ -163,9 +172,7 @@ class KPI(models.Model):
                 if is_one_value(res):
                     kpi_value = res[0]["value"]
             elif self.kpi_type == "python":
-                kpi_value = safe_eval(
-                    self.kpi_code, {"self": self, "datetime": fields.datetime}
-                )
+                kpi_value = safe_eval(self.kpi_code, self._get_eval_context())
         if isinstance(kpi_value, dict):
             res = kpi_value
         else:

--- a/kpi/tests/test_kpi.py
+++ b/kpi/tests/test_kpi.py
@@ -127,3 +127,29 @@ class TestKPI(TransactionCase):
         self.assertEqual(len(kpi_history), 1)
         self.assertEqual(kpi_history.color, "#00FF00")
         self.assertEqual(kpi_history.value, 1.0)
+
+    def test_kpi_eval_context(self):
+        kpi_category = self.env["kpi.category"].create({"name": "Dynamic KPIs"})
+        kpi_threshold = self.env["kpi.threshold"].create(
+            {"name": "KPI Threshold for dynamic KPIs"}
+        )
+        kpi = self.env["kpi"].create(
+            {
+                "name": "KPI eval context",
+                "description": "KPI to test eval context",
+                "category_id": kpi_category.id,
+                "threshold_id": kpi_threshold.id,
+                "periodicity": 1,
+                "periodicity_uom": "day",
+                "kpi_type": "python",
+                "kpi_code": "self.name == 'KPI eval context' and 1.0 or 0.0",
+            }
+        )
+        ctx = kpi._get_eval_context()
+        self.assertIn("self", ctx)
+        self.assertIn("datetime", ctx)
+        self.assertEqual(ctx["self"], kpi)
+        kpi.update_kpi_value()
+        kpi_history = self.env["kpi.history"].search([("kpi_id", "=", kpi.id)])
+        self.assertEqual(len(kpi_history), 1)
+        self.assertEqual(kpi_history.value, 1.0)


### PR DESCRIPTION
This PR introduces a `_get_eval_context` hook on the `kpi` model.

Currently, any module that wants to inject additional safe globals into Python KPI formulas has to override the entire `_get_kpi_value` method. This is fragile and duplicates core logic.

By extracting the safe_eval context into a dedicated method, other modules can simply inherit from `kpi` and override `_get_eval_context` to add their own helpers (e.g. `dateutil`, `mean`, domain-specific functions).

Changes:
- Add `kpi._get_eval_context()` returning the default context.
- Use `self._get_eval_context()` inside `_get_kpi_value` for Python KPIs.
- Add a test verifying the default context contains `self` and `datetime`, and that it is used during KPI evaluation.