### PR TITLE
[15.0][IMP] report_xlsx: remove python libs included in odoo from requirements

### DIFF
--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -9,7 +9,6 @@
     "version": "15.0.1.1.5",
     "development_status": "Mature",
     "license": "AGPL-3",
-    "external_dependencies": {"python": ["xlsxwriter", "xlrd"]},
     "depends": ["base", "web"],
     "demo": ["demo/report.xml"],
     "installable": True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ openpyxl
 py3o.formats
 py3o.template
 PyPDF2
-xlrd
-xlsxwriter


### PR DESCRIPTION
This PR removes external libs from __manifest__.py since they have already been listed in https://github.com/odoo/odoo/blob/15.0/requirements.txt

@qrtl QT6819