### PR TITLE
[19.0][FIX] bi_sql_editor: forward-port missing 17.0 improvements

### DIFF
--- a/bi_sql_editor/README.rst
+++ b/bi_sql_editor/README.rst
@@ -106,7 +106,9 @@ to make reporting depending on the current companies of the user.
 - Once the sql request checked, the module analyses the column of the
   view, and propose field mapping. For each field, you can decide to
   create an index and set if it will be displayed on the pivot graph as
-  a column, a row or a measure.
+  a column, a row or a measure. On top of that, if the field is of type
+  Many2one, you can also select the option to be clickable on the list
+  view.
 
   |image3|
 

--- a/bi_sql_editor/__manifest__.py
+++ b/bi_sql_editor/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "BI SQL Editor",
     "summary": "BI Views builder, based on Materialized or Normal SQL Views",
-    "version": "19.0.1.0.1",
+    "version": "19.0.2.0.0",
     "license": "AGPL-3",
     "category": "Reporting",
     "author": "GRAP,Odoo Community Association (OCA)",

--- a/bi_sql_editor/migrations/19.0.2.0.0/end-migration.py
+++ b/bi_sql_editor/migrations/19.0.2.0.0/end-migration.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2024 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    for view in env["bi.sql.view"].search([("state", "=", "ui_valid")]):
+        view.form_view_id = env["ir.ui.view"].create(view._prepare_form_view()).id

--- a/bi_sql_editor/migrations/19.0.2.0.0/end-migration.py
+++ b/bi_sql_editor/migrations/19.0.2.0.0/end-migration.py
@@ -8,4 +8,7 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     for view in env["bi.sql.view"].search([("state", "=", "ui_valid")]):
+        # create new Form view
         view.form_view_id = env["ir.ui.view"].create(view._prepare_form_view()).id
+        # Update tree view, to add sum / avg option
+        view.tree_view_id.write(view._prepare_tree_view())

--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -72,7 +72,8 @@ class BiSQLView(models.Model):
     view_order = fields.Char(
         required=True,
         default="pivot,graph,list",
-        help='Comma-separated text. Possible values: "graph", "pivot" or "list"',
+        help="Comma-separated text. Possible values:"
+        ' "graph", "pivot", "list" or "form"',
     )
 
     query = fields.Text(
@@ -110,6 +111,7 @@ class BiSQLView(models.Model):
     )
 
     model_id = fields.Many2one(string="Odoo Model", comodel_name="ir.model")
+
     # UI related fields
     # 1. Editable fields, which can be set by the user (optional) before
     # creating the UI elements
@@ -131,6 +133,8 @@ class BiSQLView(models.Model):
     )
 
     # 2. Readonly fields, non editable by the user
+    form_view_id = fields.Many2one(string="Odoo Form View", comodel_name="ir.ui.view")
+
     tree_view_id = fields.Many2one(string="Odoo List View", comodel_name="ir.ui.view")
 
     graph_view_id = fields.Many2one(string="Odoo Graph View", comodel_name="ir.ui.view")
@@ -173,9 +177,11 @@ class BiSQLView(models.Model):
         for rec in self:
             if rec.view_order:
                 for vtype in rec.view_order.split(","):
-                    if vtype not in ("graph", "pivot", "list"):
+                    if vtype not in ("graph", "pivot", "list", "form"):
                         raise UserError(
-                            self.env._("Only graph, pivot or list views are supported")
+                            self.env._(
+                                "Only graph, pivot, list or form views are supported"
+                            )
                         )
 
     # Compute Section
@@ -286,6 +292,7 @@ class BiSQLView(models.Model):
 
     def button_reset_to_model_valid(self):
         views = self.filtered(lambda x: x.state == "ui_valid")
+        views.mapped("form_view_id").unlink()
         views.mapped("tree_view_id").unlink()
         views.mapped("graph_view_id").unlink()
         views.mapped("pivot_view_id").unlink()
@@ -313,6 +320,7 @@ class BiSQLView(models.Model):
         return super().button_set_draft()
 
     def button_create_ui(self):
+        self.form_view_id = self.env["ir.ui.view"].create(self._prepare_form_view()).id
         self.tree_view_id = self.env["ir.ui.view"].create(self._prepare_tree_view()).id
         self.graph_view_id = (
             self.env["ir.ui.view"].create(self._prepare_graph_view()).id
@@ -406,6 +414,19 @@ class BiSQLView(models.Model):
             "global": True,
         }
 
+    def _prepare_form_view(self):
+        self.ensure_one()
+        return {
+            "name": self.name,
+            "type": "form",
+            "model": self.model_id.model,
+            "arch": """<?xml version="1.0"?>"""
+            """<form><sheet><group string="Data" col="4">{}"""
+            """</group></sheet></form>""".format(
+                "".join([x._prepare_form_field() for x in self.bi_sql_view_field_ids])
+            ),
+        }
+
     def _prepare_tree_view(self):
         self.ensure_one()
         return {
@@ -471,7 +492,9 @@ class BiSQLView(models.Model):
         self.ensure_one()
         view_mode = self.view_order
         first_view = view_mode.split(",")[0]
-        if first_view == "list":
+        if first_view == "form":
+            view_id = self.form_view_id.id
+        elif first_view == "list":
             view_id = self.tree_view_id.id
         elif first_view == "pivot":
             view_id = self.pivot_view_id.id

--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -105,6 +105,7 @@ class BiSQLViewField(models.Model):
     field_description = fields.Char(
         help="This will be used as the name of the Odoo field, displayed for users",
         required=True,
+        translate=True,
     )
 
     ttype = fields.Selection(

--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -254,8 +254,14 @@ class BiSQLViewField(models.Model):
         elif self.tree_visibility == "optional_show":
             visibility_text = 'optional="show"'
 
+        operator_text = ""
+        if self.group_operator == "sum":
+            operator_text = f'sum="{self.env._("Total")}"'
+        elif self.group_operator == "avg":
+            operator_text = f'avg="{self.env._("Average")}"'
+
         return (
-            f"""<field name="{self.name}" {visibility_text}"""
+            f"""<field name="{self.name}" {visibility_text} {operator_text}"""
             f""" context="{self.field_context}"/>\n"""
         )
 

--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -86,6 +86,12 @@ class BiSQLViewField(models.Model):
 
     index_name = fields.Char(compute="_compute_index_name")
 
+    is_many2one_clickable = fields.Boolean(
+        default=False,
+        help="If the field is of type Many2one and the option is enabled, the"
+        " field will be clickable on the list view.",
+    )
+
     graph_type = fields.Selection(
         selection=_GRAPH_TYPE_SELECTION,
     )
@@ -260,9 +266,12 @@ class BiSQLViewField(models.Model):
         elif self.group_operator == "avg":
             operator_text = f'avg="{self.env._("Average")}"'
 
+        options_text = ""
+        if self.ttype == "many2one" and self.is_many2one_clickable:
+            options_text = 'widget="many2one"'
         return (
-            f"""<field name="{self.name}" {visibility_text} {operator_text}"""
-            f""" context="{self.field_context}"/>\n"""
+            f"""<field name="{self.name}" {visibility_text} {operator_text} """
+            f"""{options_text} context="{self.field_context}"/>\n"""
         )
 
     def _prepare_graph_field(self):

--- a/bi_sql_editor/models/bi_sql_view_field.py
+++ b/bi_sql_editor/models/bi_sql_view_field.py
@@ -238,6 +238,10 @@ class BiSQLViewField(models.Model):
             or False,
         }
 
+    def _prepare_form_field(self):
+        self.ensure_one()
+        return f"""<field name="{self.name}" context="{self.field_context}"/>\n"""
+
     def _prepare_tree_field(self):
         self.ensure_one()
         if self.tree_visibility == "unavailable":

--- a/bi_sql_editor/readme/CONFIGURE.md
+++ b/bi_sql_editor/readme/CONFIGURE.md
@@ -19,7 +19,8 @@ to make reporting depending on the current companies of the user.
 - Once the sql request checked, the module analyses the column of the
   view, and propose field mapping. For each field, you can decide to
   create an index and set if it will be displayed on the pivot graph as
-  a column, a row or a measure.
+  a column, a row or a measure. On top of that, if the field is of type
+  Many2one, you can also select the option to be clickable on the list view.
 
   ![](../static/description/03_field_mapping.png)
 

--- a/bi_sql_editor/static/description/index.html
+++ b/bi_sql_editor/static/description/index.html
@@ -443,7 +443,9 @@ to make reporting depending on the current companies of the user.</p>
 <li><p class="first">Once the sql request checked, the module analyses the column of the
 view, and propose field mapping. For each field, you can decide to
 create an index and set if it will be displayed on the pivot graph as
-a column, a row or a measure.</p>
+a column, a row or a measure. On top of that, if the field is of type
+Many2one, you can also select the option to be clickable on the list
+view.</p>
 <p><img alt="image3" src="https://raw.githubusercontent.com/OCA/reporting-engine/19.0/bi_sql_editor/static/description/03_field_mapping.png" /></p>
 </li>
 <li><p class="first">Click on the button ‘Create SQL elements’. (this step could take a

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -219,6 +219,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 />
                             </group>
                             <group string="UI Instances">
+                                <field name="form_view_id" readonly="1" />
                                 <field name="tree_view_id" readonly="1" />
                                 <field name="graph_view_id" readonly="1" />
                                 <field name="pivot_view_id" readonly="1" />

--- a/bi_sql_editor/views/view_bi_sql_view.xml
+++ b/bi_sql_editor/views/view_bi_sql_view.xml
@@ -129,6 +129,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 readonly="state in ('model_valid', 'ui_valid')"
                             />
                             <field
+                                name="is_many2one_clickable"
+                                invisible="not field_description or ttype != 'many2one'"
+                                optional="show"
+                            />
+                            <field
                                 name="selection"
                                 invisible="ttype != 'selection'"
                                 required="ttype == 'selection'"


### PR DESCRIPTION
Forward-ports to 19.0 the bi_sql_editor changes merged in 17.0 that never reached this branch, with original authorship preserved (cherry-pick -x):

- #908: form view for SQL views + sum/avg aggregates in list view (adapted: tree → list terminology, self.env._, migration script renamed to 19.0.2.0.0; also fixes an if that should be elif in _prepare_action which made form-first views open the graph view)
- #1079: clickable many2one in list view
- #1086: field_description with translate=True

Not ported: #1036, already present in 19.0 via 637db79fb.

Version bumped to 19.0.2.0.0. Tests green (5 post-install tests), pre-commit green.