### PR TITLE
[IMP] report_substitute: add hook to render non-qweb-pdf substitutio reports

### DIFF
--- a/report_substitute/models/ir_actions_report.py
+++ b/report_substitute/models/ir_actions_report.py
@@ -57,13 +57,28 @@ class IrActionReport(models.Model):
             substitution_report.report_name, res_ids, data=data
         )
 
-    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
-        report = self._get_report(report_ref)
-        substitution_report = report.get_substitution_report(res_ids)
+    def _render_qweb_pdf_substitution(
+        self, substitution_report, res_ids=None, data=None
+    ):
+        """Hook to render substitution reports with another report_type.
+
+        Return a ``(content, report_type)`` tuple, or ``None`` to fall
+        back to rendering the original report.
+        """
         if substitution_report.filtered(lambda r: r.report_type == "qweb-pdf"):
             return super(IrActionReport, self)._render_qweb_pdf(
                 substitution_report, res_ids=res_ids, data=data
             )
+        return None
+
+    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
+        report = self._get_report(report_ref)
+        substitution_report = report.get_substitution_report(res_ids)
+        result = self._render_qweb_pdf_substitution(
+            substitution_report, res_ids=res_ids, data=data
+        )
+        if result is not None:
+            return result
         return super(IrActionReport, self)._render_qweb_pdf(
             report_ref, res_ids=res_ids, data=data
         )

--- a/report_substitute/tests/test_report_substitute.py
+++ b/report_substitute/tests/test_report_substitute.py
@@ -103,3 +103,14 @@ class TestReportSubstitute(TransactionCase):
                     ).id,
                 }
             )
+
+    def test_render_qweb_pdf_falls_back_for_non_qweb_substitute(self):
+        # A substitute whose report_type is not qweb-pdf cannot be rendered
+        # by _render_qweb_pdf, which should fall back to the original report.
+        self.substitution_rule.substitution_action_report_id.report_type = "qweb-text"
+        res = str(
+            self.action_report._render_qweb_pdf(
+                self.action_report.report_name, res_ids=self.res_ids
+            )[0]
+        )
+        self.assertNotIn('<div class="page">Substitution Report</div>', res)


### PR DESCRIPTION
_render_qweb_pdf only substitutes when the resolved substitution report's report_type is qweb-pdf; otherwise it silently falls back to rendering the original report. Extract that decision into an overridable _render_qweb_pdf_substitution hook so modules introducing other report types can render their own substitution reports on this path.