### PR TITLE
[19.0][FIX] report_async: invalidate ORM cache after raw SQL update

### DIFF
--- a/report_async/models/report_async.py
+++ b/report_async/models/report_async.py
@@ -164,6 +164,7 @@ class ReportAsync(models.Model):
             WHERE id = %s""",
             (self.env.uid, self.env.uid, attachment.id),
         )
+        attachment.invalidate_recordset(["create_uid", "write_uid"])
         # Send email
         if self.email_notify:
             self._send_email(attachment)


### PR DESCRIPTION
After creating the attachment with SUPERUSER_ID, run_report updates create_uid/write_uid via a raw SQL execute().  
The ORM cache is not invalidated, so when _send_email() renders the template the attachment.create_uid still holds SUPERUSER_ID (OdooBot) instead of the actual user, producing "Dear OdooBot" in the notification email.

This small fix will add attachment.invalidate_recordset(["create_uid", "write_uid"]) just after the cr.execute() block so the template reads the correct value.