### PR TITLE
[FIX] report_qweb_encrypt: accept single res_id

### DIFF
--- a/report_qweb_encrypt/models/ir_actions_report.py
+++ b/report_qweb_encrypt/models/ir_actions_report.py
@@ -33,6 +33,8 @@ class IrActionsReport(models.Model):
         )
         report_sudo = self._get_report(report_ref)
         if res_ids:
+            if isinstance(res_ids, int):
+                res_ids = [res_ids]
             encrypt_password = self.env.context.get("encrypt_password")
             report = self._get_report_from_name(report_sudo.report_name).with_context(
                 encrypt_password=encrypt_password

--- a/report_qweb_encrypt/tests/test_report_qweb_encrypt.py
+++ b/report_qweb_encrypt/tests/test_report_qweb_encrypt.py
@@ -40,12 +40,12 @@ class TestReportQwebEncrypt(HttpCase):
         report.encrypt = "manual"
 
         # If no encrypt_password, still not encrypted
-        pdf, _ = report.with_context(**ctx)._render_qweb_pdf(report.report_name, [1])
+        pdf, _ = report.with_context(**ctx)._render_qweb_pdf(report.report_name, 1)
         self.assertFalse(pdf.count(b"/Encrypt"))
 
         # Valid python string for password
         ctx.update({"encrypt_password": "secretcode"})
-        pdf, _ = report.with_context(**ctx)._render_qweb_pdf(report.report_name, [1])
+        pdf, _ = report.with_context(**ctx)._render_qweb_pdf(report.report_name, 1)
         self.assertTrue(pdf.count(b"/Encrypt"))
 
     # TODO: test_report_qweb_manual_encrypt, require JS test?


### PR DESCRIPTION
Odoo's PDF report API accepts `res_ids` either as a list or as a single integer. This mirrors how Odoo normalizes `res_ids` internally before continuing the rendering flow:

- https://github.com/odoo/odoo/blob/80e1a4464f75df5beeae0d8205a282da755c1a7d/odoo/addons/base/models/ir_actions_report.py#L659

There are real callers that use the single-id form. For example, `stock.picking` renders the delivery report with `self.id`:

- https://github.com/odoo/odoo/blob/ba4315ec85341431dd9bcd4f4d64217c37a4865f/addons/stock/models/stock_picking.py#L2014

`report_qweb_encrypt` kept using the original `res_ids` value after calling `super()` and sliced it to evaluate the encryption password. When a caller passed a single id, slicing the integer raised `TypeError` before the password could be read.

This change normalizes the local value before calling `_get_pdf_password` and adds a regression test for the single-id form.