### PR TITLE
[19.0][FIX] report_async: Incorrect definition report id

### DIFF
--- a/report_async/models/ir_report.py
+++ b/report_async/models/ir_report.py
@@ -13,7 +13,7 @@ class Report(models.Model):
     def report_action(self, docids, data=None, config=True):
         res = super().report_action(docids, data=data, config=config)
         if res["context"].get("async_process", False):
-            rpt_async_id = res["context"]["active_id"]
+            rpt_async_id = res["context"]["report_async_id"]
             report_async = self.env["report.async"].browse(rpt_async_id)
             if res["report_type"] in REPORT_TYPES:
                 report_async.with_delay().run_report(

--- a/report_async/models/report_async.py
+++ b/report_async/models/report_async.py
@@ -115,7 +115,7 @@ class ReportAsync(models.Model):
             raise UserError(self.env._("Background process not allowed."))
         result = self.env[self.action_id.type]._for_xml_id(self.action_id.xml_id)
         ctx = safe_eval(result.get("context", {}))
-        ctx.update({"async_process": True})
+        ctx.update({"async_process": True, "report_async_id": self.id})
         result["context"] = ctx
         return result
 

--- a/report_async/tests/test_report_async.py
+++ b/report_async/tests/test_report_async.py
@@ -27,6 +27,7 @@ class TestJobChannel(TransactionCase):
                 active_model=self.print_doc._name,
                 active_id=self.print_doc.id,
                 async_process=res["context"].get("async_process"),
+                report_async_id=res["context"].get("report_async_id"),
             )
         ) as form:
             form.reference = f"{self.test_rec._name},{self.test_rec.id}"


### PR DESCRIPTION
**Issue Description:** 

When an asynchronous report uses a multi-step wizard—for example, when users enter filters, open a preview, and then download the report—the preview replaces active_id with the wizard record ID. report_async incorrectly uses this value as the report.async record ID, causing the job to fail with MissingError.

e.g.:

<img width="1779" height="838" alt="image" src="https://github.com/user-attachments/assets/6e38e2a0-6780-4452-a622-a2d9ac61e5a0" />
<img width="1512" height="366" alt="image" src="https://github.com/user-attachments/assets/0bde6b56-5220-491f-a5be-d134f576bb45" />

**After this PR:** 

The Report Center record ID is stored in report_async_id, so wizard navigation can update active_id without breaking asynchronous report generation.