### PR TITLE
[FIX] report_xlsx: sanitize worksheet name to prevent InvalidWorksheetName

### DIFF
--- a/report_xlsx/report/report_abstract_xlsx.py
+++ b/report_xlsx/report/report_abstract_xlsx.py
@@ -24,6 +24,12 @@ try:
             hard to debug the original issue. Even so, different names can become the
             same one as their strings are trimmed to those 31 character limit.
 
+            In order to avoid the library raising InvalidWorksheetName because the
+            report name contains invalid characters, or starts/ends with one of
+            them, we sanitize the name here. The sanitization is applied before
+            the library check and before the duplicate check so it can never
+            leave a name that errors again.
+
             This way, once we come across with a duplicated, we set that final 3
             characters with a sequence that we evaluate on the fly. So for instance:
 
@@ -37,6 +43,7 @@ try:
               the strings too much and keeping in mind that this issue don't usually
               ocurrs.
             """
+            sheetname = self._sanitize_sheetname(sheetname)
             try:
                 return super()._check_sheetname(sheetname, is_chartsheet=is_chartsheet)
             except xlsxwriter.exceptions.DuplicateWorksheetName:
@@ -56,6 +63,20 @@ try:
                     sheetname = sheetname[:28] + deduplicated_secuence
             # Refeed the method until we get an unduplicated name
             return self._check_sheetname(sheetname, is_chartsheet=is_chartsheet)
+
+        def _sanitize_sheetname(self, sheetname):
+            """Return a sheet name that xlsxwriter accepts.
+
+            Excel worksheet names are limited to 31 characters, cannot contain
+            ``[]:*?/\\`` and cannot start or end with an apostrophe. Those
+            constraints are not guaranteed by report names, so we normalize the
+            name accordingly.
+            """
+            if not sheetname:
+                return sheetname
+            sheetname = re.sub(r"[\[\]:*?/\\]", "", sheetname)
+            sheetname = sheetname[:31]
+            return sheetname.strip("'")
 
     # "Short string"
 

--- a/report_xlsx/tests/test_report.py
+++ b/report_xlsx/tests/test_report.py
@@ -91,3 +91,22 @@ class TestReport(common.TransactionCase):
         self.assertEqual(
             self.xlsx_report._report_xlsx_currency_format(eur), "#,##0.00 €"
         )
+
+    def test_sanitize_sheetname(self):
+        from io import BytesIO
+
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook(BytesIO(), {"constant_memory": True})
+        sanitize = workbook._sanitize_sheetname
+        # It must not end with an apostrophe.
+        self.assertEqual("VAT Report - Company", sanitize("VAT Report - Company'"))
+        self.assertEqual("VAT Report - Company", sanitize("VAT Report - Company''"))
+        # It must not start with an apostrophe.
+        self.assertEqual("VAT Report - Company", sanitize("'VAT Report - Company"))
+        # Forbidden characters are removed.
+        self.assertEqual("VAT Report draft  Q1", sanitize("VAT Report [draft] : Q1"))
+        self.assertEqual("WeeklyExportColumn", sanitize("Weekly\\Export/Column:?"))
+        # Longer than 31 chars is truncated.
+        self.assertEqual("X" * 31, sanitize("X" * 40))
+        workbook.close()


### PR DESCRIPTION
Excel worksheet names are limited to 31 characters, cannot contain []:*?/\ and cannot start or end with an apostrophe. Report names do not guarantee these constraints, so xlsxwriter can raise InvalidWorksheetName (e.g. when a report name ends with an apostrophe once truncated to 31 chars).

Sanitize the sheet name in PatchedXlsxWorkbook._check_sheetname before the library validation and the duplicate handling, so a normalized name never triggers the error again. Add a test covering forbidden characters, leading/trailing apostrophes and length truncation.